### PR TITLE
Remove unnecessary Hive configs from Spark

### DIFF
--- a/compose/trino-spark/conf/spark/hive-site.xml
+++ b/compose/trino-spark/conf/spark/hive-site.xml
@@ -41,14 +41,4 @@
     <name>datanucleus.autoCreateSchema</name>
     <value>false</value>
   </property>
-
-  <!-- Configure Metastore for Storage Based Authorization -->
-  <property>
-    <name>hive.metastore.pre.event.listeners</name>
-    <value>org.apache.hadoop.hive.ql.security.authorization.plugin.metastore.HiveMetaStoreAuthorizer</value>
-  </property>
-  <property>
-    <name>hive.security.authorization.enabled</name>
-    <value>true</value>
-  </property>
 </configuration>


### PR DESCRIPTION
While working on https://github.com/G-Research/gr-oss/issues/620, I did extensive testing of all the Hive security configs. I found out that Spark, just like Trino, doesn't need to be aware of any Hive security properties at all. Security must be set up only on the HiveMetastore side.