### PR TITLE
gr-oss-625. Improve retryOperationIfNeeded() output

### DIFF
--- a/trino-hms-hdfs-ranger/setup/setup_for_testing_hms_policies.sh
+++ b/trino-hms-hdfs-ranger/setup/setup_for_testing_hms_policies.sh
@@ -17,8 +17,8 @@ echo "- INFO: Updating Ranger policies. Users [spark/postgres] will now have all
 # then check that message doesn't contain Permission denied.
 sparkNotExpMsg="Permission denied"
 
-retryOperationIfNeeded "$abs_path" "createSparkTable $SPARK_TABLE $HDFS_DIR" "$sparkNotExpMsg" "false" "true"
+retryOperationIfNeeded "$abs_path" "createSparkTable $SPARK_TABLE $HDFS_DIR $DEFAULT_DB" "$sparkNotExpMsg" "false" "true"
 
 trinoSuccessMsg="CREATE TABLE"
 
-retryOperationIfNeeded "$abs_path" "createTrinoTable $TRINO_TABLE $HDFS_DIR" "$successMsg" "false"
+retryOperationIfNeeded "$abs_path" "createTrinoTable $TRINO_TABLE $HDFS_DIR $DEFAULT_DB" "$successMsg" "false"

--- a/trino-hms-hdfs-ranger/setup/setup_for_trino_spark_testing.sh
+++ b/trino-hms-hdfs-ranger/setup/setup_for_trino_spark_testing.sh
@@ -20,6 +20,7 @@ notExpMsg="Permission denied"
 retryOperationIfNeeded "$abs_path" "createHdfsDir $HDFS_DIR" "$notExpMsg" "false" "true"
 
 notExpMsg="Permission denied"
-retryOperationIfNeeded "$abs_path" "addHdfsTestFileUnderDir $HDFS_DIR" "$notExpMsg" "false" "true"
+retryOperationIfNeeded "$abs_path" "createHdfsFile $HDFS_DIR" "$notExpMsg" "false" "true"
 
-createHdfsDir "$HIVE_WAREHOUSE_DIR"
+notExpMsg="Permission denied"
+retryOperationIfNeeded "$abs_path" "createHdfsDir $HIVE_WAREHOUSE_DIR" "$notExpMsg" "false" "true"

--- a/trino-hms-hdfs-ranger/setup/setup_for_trino_spark_testing.sh
+++ b/trino-hms-hdfs-ranger/setup/setup_for_trino_spark_testing.sh
@@ -16,7 +16,22 @@ abs_path=$1
 # "$HDFS_AND_HIVE_ALL" + some very limited for URL based auth in Hive.
 ./setup/load_ranger_policies.sh "$abs_path" "$DEFAULT_AND_NO_HIVE"
 
-createHdfsDir "$HDFS_DIR"
-createHdfsFile "$HDFS_DIR"
+# Print cmd first.
+createHdfsDir "$HDFS_DIR" "true"
+
+if createHdfsDir "$HDFS_DIR"; then
+  # Print cmd first.
+  addHdfsTestFileUnderDir "$HDFS_DIR" "true"
+  if addHdfsTestFileUnderDir "$HDFS_DIR"; then
+    echo ""
+    echo "- RESULT: HDFS test data creation succeeded."
+  else
+    echo ""
+    echo "- RESULT: HDFS test data creation failed."
+  fi
+else
+  echo ""
+  echo "- RESULT: HDFS test data creation failed."
+fi
 
 createHdfsDir "$HIVE_WAREHOUSE_DIR"

--- a/trino-hms-hdfs-ranger/setup/setup_for_trino_spark_testing.sh
+++ b/trino-hms-hdfs-ranger/setup/setup_for_trino_spark_testing.sh
@@ -16,22 +16,10 @@ abs_path=$1
 # "$HDFS_AND_HIVE_ALL" + some very limited for URL based auth in Hive.
 ./setup/load_ranger_policies.sh "$abs_path" "$DEFAULT_AND_NO_HIVE"
 
-# Print cmd first.
-createHdfsDir "$HDFS_DIR" "true"
+notExpMsg="Permission denied"
+retryOperationIfNeeded "$abs_path" "createHdfsDir $HDFS_DIR" "$notExpMsg" "false" "true"
 
-if createHdfsDir "$HDFS_DIR"; then
-  # Print cmd first.
-  addHdfsTestFileUnderDir "$HDFS_DIR" "true"
-  if addHdfsTestFileUnderDir "$HDFS_DIR"; then
-    echo ""
-    echo "- RESULT: HDFS test data creation succeeded."
-  else
-    echo ""
-    echo "- RESULT: HDFS test data creation failed."
-  fi
-else
-  echo ""
-  echo "- RESULT: HDFS test data creation failed."
-fi
+notExpMsg="Permission denied"
+retryOperationIfNeeded "$abs_path" "addHdfsTestFileUnderDir $HDFS_DIR" "$notExpMsg" "false" "true"
 
 createHdfsDir "$HIVE_WAREHOUSE_DIR"

--- a/trino-hms-hdfs-ranger/testlib.sh
+++ b/trino-hms-hdfs-ranger/testlib.sh
@@ -725,10 +725,12 @@ createTrinoTable() {
   hdfs_dir_name=$2
   schema_name=$3
 
+  c="create table hive.$schema_name.$table_name (column1 varchar,column2 varchar) with (external_location = 'hdfs://namenode:8020/$hdfs_dir_name',format = 'CSV');"
+
   if [ "$PRINT_CMD" == "true" ]; then
-    printCmdString "create table hive.$schema_name.$table_name (column1 varchar,column2 varchar) with (external_location = 'hdfs://namenode:8020/$hdfs_dir_name',format = 'CSV');"
+    printCmdString "$c"
   else
-    docker exec -it "$TRINO_HOSTNAME" trino --execute="create table hive.$schema_name.$table_name (column1 varchar,column2 varchar) with (external_location = 'hdfs://namenode:8020/$hdfs_dir_name',format = 'CSV');"
+    docker exec -it "$TRINO_HOSTNAME" trino --execute="$c"
   fi
 }
 
@@ -736,10 +738,12 @@ selectDataFromTrinoTable() {
   table_name=$1
   schema_name=$2
 
+  c="select * from hive.$schema_name.$table_name;"
+
   if [ "$PRINT_CMD" == "true" ]; then
-    printCmdString "select * from hive.$schema_name.$table_name;"
+    printCmdString "$c"
   else
-    docker exec -it "$TRINO_HOSTNAME" trino --execute="select * from hive.$schema_name.$table_name;"
+    docker exec -it "$TRINO_HOSTNAME" trino --execute="$c"
   fi
 }
 
@@ -748,10 +752,12 @@ alterTrinoTable() {
   new_table_name=$2
   schema_name=$3
 
+  c="alter table hive.$schema_name.$old_table_name rename to $new_table_name;"
+
   if [ "$PRINT_CMD" == "true" ]; then
-    printCmdString "alter table hive.$schema_name.$old_table_name rename to $new_table_name;"
+    printCmdString "$c"
   else
-    docker exec -it "$TRINO_HOSTNAME" trino --execute="alter table hive.$schema_name.$old_table_name rename to $new_table_name;"
+    docker exec -it "$TRINO_HOSTNAME" trino --execute="$c"
   fi
 }
 
@@ -759,20 +765,24 @@ dropTrinoTable() {
   table_name=$1
   schema_name=$2
 
+  c="drop table hive.$schema_name.$table_name;"
+
   if [ "$PRINT_CMD" == "true" ]; then
-    printCmdString "drop table hive.$schema_name.$table_name;"
+    printCmdString "$c"
   else
-    docker exec -it "$TRINO_HOSTNAME" trino --execute="drop table hive.$schema_name.$table_name;"
+    docker exec -it "$TRINO_HOSTNAME" trino --execute="$c"
   fi
 }
 
 createSchemaWithTrino() {
   schema_name=$1
 
+  c="CREATE SCHEMA hive.$schema_name WITH (location = 'hdfs://namenode/opt/hive/data/$schema_name/external/$schema_name.db');"
+
   if [ "$PRINT_CMD" == "true" ]; then
-    printCmdString "CREATE SCHEMA hive.$schema_name WITH (location = 'hdfs://namenode/opt/hive/data/$schema_name/external/$schema_name.db');"
+    printCmdString "$c"
   else
-    docker exec -it "$TRINO_HOSTNAME" trino --execute="CREATE SCHEMA hive.$schema_name WITH (location = 'hdfs://namenode/opt/hive/data/$schema_name/external/$schema_name.db');"
+    docker exec -it "$TRINO_HOSTNAME" trino --execute="$c"
   fi
 }
 
@@ -781,16 +791,22 @@ dropSchemaWithTrino() {
   use_cascade=$2
 
   if [ "$use_cascade" == "true" ]; then
+
+    c="DROP SCHEMA hive.$schema_name CASCADE;"
+
     if [ "$PRINT_CMD" == "true" ]; then
-      printCmdString "DROP SCHEMA hive.$schema_name CASCADE;"
+      printCmdString "$c"
     else
-      docker exec -it "$TRINO_HOSTNAME" trino --execute="DROP SCHEMA hive.$schema_name CASCADE;"
+      docker exec -it "$TRINO_HOSTNAME" trino --execute="$c"
     fi
   else
+
+    c="DROP SCHEMA hive.$schema_name;"
+
     if [ "$PRINT_CMD" == "true" ]; then
-      printCmdString "DROP SCHEMA hive.$schema_name;"
+      printCmdString "$c"
     else
-      docker exec -it "$TRINO_HOSTNAME" trino --execute="DROP SCHEMA hive.$schema_name;"
+      docker exec -it "$TRINO_HOSTNAME" trino --execute="$c"
     fi
   fi
 }
@@ -904,6 +920,8 @@ createOrUpdateLastSuccessFile() {
   echo "Branch: $hive_branch" >> "$abs_path/$CURRENT_REPO/$LAST_SUCCESS_FILE"
   echo "Commit: $hive_commit_SHA" >> "$abs_path/$CURRENT_REPO/$LAST_SUCCESS_FILE"
   echo "" >> "$abs_path/$CURRENT_REPO/$LAST_SUCCESS_FILE"
+
+  # TODO: add Spark.
 }
 
 retryOperationIfNeeded() {

--- a/trino-hms-hdfs-ranger/testlib.sh
+++ b/trino-hms-hdfs-ranger/testlib.sh
@@ -20,12 +20,16 @@ HIVE_BUILD=
 
 configureHiveVersion() {
   if [[ "${HIVE_VERSION}" == "4" ]]; then
+    echo ""
     echo "Configuring project for Hive 4."
+    echo ""
     HIVE_BRANCH="hive4-latest"
     HIVE_BUILD="4.0.0-beta-2-SNAPSHOT"
     RANGER_BRANCH="ranger-docker-hive4"
   else
+    echo ""
     echo "Configuring project for Hive 3."
+    echo ""
     HIVE_BRANCH="branch-3.1-build-fixed"
     HIVE_BUILD="3.1.3"
     RANGER_BRANCH="ranger-docker-hdfs"
@@ -613,9 +617,30 @@ addHdfsTestFileUnderDir() {
 }
 
 performSparkSql() {
-  # Join all args with space
-  sql="$*"
-  docker exec -it "$SPARK_MASTER_HOSTNAME" bash -c "echo \"$sql\" | bin/spark-shell"
+  # Store all args in an array.
+  args=("$@")
+
+  # Initialize to empty, or declare it local.
+  print=""
+
+  # If the last arg is "true", then 'print' is set.
+  if [[ "${args[-1]}" == "true" ]]; then
+    echo "Print is set."
+    print="true"
+    # Remove the print arg from the array.
+    unset args[-1]
+  fi
+
+  # Join all array arguments into a string with spaces.
+  sql=$(printf "%s " "${args[@]}")
+  # Trim the trailing space.
+  sql=${sql% }
+
+  if [ "$print" == "true" ]; then
+    printCmdString "$sql"
+  else
+    docker exec -it "$SPARK_MASTER_HOSTNAME" bash -c "echo \"$sql\" | bin/spark-shell"
+  fi
 }
 
 createSparkTable() {

--- a/trino-hms-hdfs-ranger/testlib.sh
+++ b/trino-hms-hdfs-ranger/testlib.sh
@@ -62,6 +62,7 @@ HIVE_WAREHOUSE_DIR="opt/hive/data"
 TMP_FILE="tmp_output.txt"
 PG_TMP_OUT_FILE="pg_tmp_output.txt"
 LAST_SUCCESS_FILE="lastSuccess.txt"
+PRINT_CMD=""
 
 # Container names
 # Compose V2
@@ -142,9 +143,6 @@ CALCITE_CORE_JAR_NAME="calcite-core-1.36.0.jar"
 TABLE_PERSONS="persons"
 TABLE_ANIMALS="animals"
 TABLE_SPORTS="sports"
-
-# Shared Variables
-PRINT_CMD=""
 
 getHostnameFromName() {
   name=$1
@@ -588,54 +586,26 @@ createHdfsDir() {
   dir_name=$1
 
   if [ "$PRINT_CMD" == "true" ]; then
-    printCmdString "hdfs dfs -mkdir /$dir_name"
+    printCmdString "hdfs dfs -mkdir -p /$dir_name"
   else
-    docker exec -it "$DN1_HOSTNAME" hdfs dfs -mkdir "/$dir_name"
+    docker exec -it "$DN1_HOSTNAME" hdfs dfs -mkdir -p "/$dir_name"
   fi
 }
 
 createHdfsFile() {
   dir_name=$1
-  file_name="test.csv"
-
-  echo ""
-  if docker exec -it "$DN1_HOSTNAME" hdfs dfs -put "$file_name" "/$dir_name"; then
-    echo "- INFO: Creation of HDFS file:/$dir_name/$file_name succeeded."
-  else
-    echo "- ERROR: Creation of HDFS file:/$dir_name/$file_name failed."
-    exit 1
-  fi
-}
-
-addHdfsTestFileUnderDir() {
-  dir_name=$1
+  file_name=${2:-"test.csv"} # Provide a default value if not set.
 
   if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "hdfs dfs -put test.csv /$dir_name"
   else
-    docker exec -it "$DN1_HOSTNAME" hdfs dfs -put test.csv "/$dir_name"
+    docker exec -it "$DN1_HOSTNAME" hdfs dfs -put "$file_name" "/$dir_name"
   fi
 }
 
 performSparkSql() {
-  # Store all args in an array.
-  args=("$@")
-
-  # Initialize to empty, or declare it local.
-  print=""
-
-  # If the last arg is "true", then 'print' is set.
-  if [[ "${args[-1]}" == "true" ]]; then
-    echo "Print is set."
-    print="true"
-    # Remove the print arg from the array.
-    unset args[-1]
-  fi
-
-  # Join all array arguments into a string with spaces.
-  sql=$(printf "%s " "${args[@]}")
-  # Trim the trailing space.
-  sql=${sql% }
+  # Join all args with space
+  sql="$*"
 
   if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "$sql"
@@ -721,8 +691,13 @@ dropDatabaseWithSpark() {
 
 performTrinoCmd() {
   # Join all args with space
-  cmd="$*"
-  docker exec -it "$TRINO_HOSTNAME" trino --execute="$cmd"
+  trino_cmd="$*"
+
+  if [ "$PRINT_CMD" == "true" ]; then
+    printCmdString "$trino_cmd"
+  else
+    docker exec -it "$TRINO_HOSTNAME" trino --execute="$trino_cmd"
+  fi
 }
 
 createTrinoTable() {
@@ -983,6 +958,7 @@ retryOperationIfNeeded() {
         echo "- Not expected msg: $expMsg"
         echo ""
         echo "- RESULT -> SUCCESS: Operation $result as expected."
+        echo "---------------------------------------------------"
         break
       fi
 
@@ -1016,6 +992,7 @@ retryOperationIfNeeded() {
         echo "- Expected Msg: $expMsg"
         echo ""
         echo "- RESULT -> SUCCESS: Operation $result as expected."
+        echo "---------------------------------------------------"
         break
       fi
 

--- a/trino-hms-hdfs-ranger/testlib.sh
+++ b/trino-hms-hdfs-ranger/testlib.sh
@@ -143,6 +143,9 @@ TABLE_PERSONS="persons"
 TABLE_ANIMALS="animals"
 TABLE_SPORTS="sports"
 
+# Shared Variables
+PRINT_CMD=""
+
 getHostnameFromName() {
   name=$1
 
@@ -583,9 +586,8 @@ printCmdString() {
 
 createHdfsDir() {
   dir_name=$1
-  print=$2
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "hdfs dfs -mkdir /$dir_name"
   else
     docker exec -it "$DN1_HOSTNAME" hdfs dfs -mkdir "/$dir_name"
@@ -607,9 +609,8 @@ createHdfsFile() {
 
 addHdfsTestFileUnderDir() {
   dir_name=$1
-  print=$2
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "hdfs dfs -put test.csv /$dir_name"
   else
     docker exec -it "$DN1_HOSTNAME" hdfs dfs -put test.csv "/$dir_name"
@@ -636,7 +637,7 @@ performSparkSql() {
   # Trim the trailing space.
   sql=${sql% }
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "$sql"
   else
     docker exec -it "$SPARK_MASTER_HOSTNAME" bash -c "echo \"$sql\" | bin/spark-shell"
@@ -647,9 +648,8 @@ createSparkTable() {
   table_name=$1
   hdfs_dir_name=$2
   db_name=$3
-  print=$4
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "spark.read.text(\"hdfs://namenode:8020/$hdfs_dir_name\").write.option(\"path\", \"hdfs://namenode/opt/hive/data\").mode(\"overwrite\").format(\"csv\").saveAsTable(\"$db_name.$table_name\")"
   else
     docker exec -it "$SPARK_MASTER_HOSTNAME" bash -c "echo \"spark.read.text(\\\"hdfs://namenode:8020/$hdfs_dir_name\\\").write.option(\\\"path\\\", \\\"hdfs://namenode/opt/hive/data\\\").mode(\\\"overwrite\\\").format(\\\"csv\\\").saveAsTable(\\\"$db_name.$table_name\\\")\" | bin/spark-shell"
@@ -659,9 +659,8 @@ createSparkTable() {
 selectDataFromSparkTable() {
   table_name=$1
   db_name=$2
-  print=$3
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "spark.sql(\"SELECT * FROM $db_name.$table_name\").show()"
   else
     docker exec -it "$SPARK_MASTER_HOSTNAME" bash -c "echo \"spark.sql(\\\"SELECT * FROM $db_name.$table_name\\\").show()\" | bin/spark-shell"
@@ -672,9 +671,8 @@ alterSparkTable() {
   old_table_name=$1
   new_table_name=$2
   db_name=$3
-  print=$4
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "spark.sql(\"ALTER TABLE $db_name.$old_table_name RENAME TO $db_name.$new_table_name\")"
   else
     docker exec -it "$SPARK_MASTER_HOSTNAME" bash -c "echo \"spark.sql(\\\"ALTER TABLE $db_name.$old_table_name RENAME TO $db_name.$new_table_name\\\")\" | bin/spark-shell"
@@ -684,9 +682,8 @@ alterSparkTable() {
 dropSparkTable() {
   table_name=$1
   db_name=$2
-  print=$3
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "spark.sql(\"DROP TABLE $db_name.$table_name\")"
   else
     docker exec -it "$SPARK_MASTER_HOSTNAME" bash -c "echo \"spark.sql(\\\"DROP TABLE $db_name.$table_name\\\")\" | bin/spark-shell"
@@ -695,9 +692,8 @@ dropSparkTable() {
 
 createDatabaseWithSpark() {
   db_name=$1
-  print=$2
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "spark.sql(\"CREATE DATABASE $db_name LOCATION 'hdfs://namenode/opt/hive/data/$db_name/external/$db_name.db'\")"
   else
     docker exec -it "$SPARK_MASTER_HOSTNAME" bash -c "echo \"spark.sql(\\\"CREATE DATABASE $db_name LOCATION 'hdfs://namenode/opt/hive/data/$db_name/external/$db_name.db'\\\")\" | bin/spark-shell"
@@ -707,16 +703,15 @@ createDatabaseWithSpark() {
 dropDatabaseWithSpark() {
   db_name=$1
   use_cascade=$2
-  print=$3
 
   if [ "$use_cascade" == "true" ]; then
-    if [ "$print" == "true" ]; then
+    if [ "$PRINT_CMD" == "true" ]; then
       printCmdString "spark.sql(\"DROP DATABASE IF EXISTS $db_name CASCADE\")"
     else
       docker exec -it "$SPARK_MASTER_HOSTNAME" bash -c "echo \"spark.sql(\\\"DROP DATABASE IF EXISTS $db_name CASCADE\\\")\" | bin/spark-shell"
     fi
   else
-    if [ "$print" == "true" ]; then
+    if [ "$PRINT_CMD" == "true" ]; then
       printCmdString "spark.sql(\"DROP DATABASE IF EXISTS $db_name\")"
     else
       docker exec -it "$SPARK_MASTER_HOSTNAME" bash -c "echo \"spark.sql(\\\"DROP DATABASE IF EXISTS $db_name\\\")\" | bin/spark-shell"
@@ -734,9 +729,8 @@ createTrinoTable() {
   table_name=$1
   hdfs_dir_name=$2
   schema_name=$3
-  print=$4
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "create table hive.$schema_name.$table_name (column1 varchar,column2 varchar) with (external_location = 'hdfs://namenode:8020/$hdfs_dir_name',format = 'CSV');"
   else
     docker exec -it "$TRINO_HOSTNAME" trino --execute="create table hive.$schema_name.$table_name (column1 varchar,column2 varchar) with (external_location = 'hdfs://namenode:8020/$hdfs_dir_name',format = 'CSV');"
@@ -746,9 +740,8 @@ createTrinoTable() {
 selectDataFromTrinoTable() {
   table_name=$1
   schema_name=$2
-  print=$3
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "select * from hive.$schema_name.$table_name;"
   else
     docker exec -it "$TRINO_HOSTNAME" trino --execute="select * from hive.$schema_name.$table_name;"
@@ -759,9 +752,8 @@ alterTrinoTable() {
   old_table_name=$1
   new_table_name=$2
   schema_name=$3
-  print=$4
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "alter table hive.$schema_name.$old_table_name rename to $new_table_name;"
   else
     docker exec -it "$TRINO_HOSTNAME" trino --execute="alter table hive.$schema_name.$old_table_name rename to $new_table_name;"
@@ -771,9 +763,8 @@ alterTrinoTable() {
 dropTrinoTable() {
   table_name=$1
   schema_name=$2
-  print=$3
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "drop table hive.$schema_name.$table_name;"
   else
     docker exec -it "$TRINO_HOSTNAME" trino --execute="drop table hive.$schema_name.$table_name;"
@@ -782,9 +773,8 @@ dropTrinoTable() {
 
 createSchemaWithTrino() {
   schema_name=$1
-  print=$2
 
-  if [ "$print" == "true" ]; then
+  if [ "$PRINT_CMD" == "true" ]; then
     printCmdString "CREATE SCHEMA hive.$schema_name WITH (location = 'hdfs://namenode/opt/hive/data/$schema_name/external/$schema_name.db');"
   else
     docker exec -it "$TRINO_HOSTNAME" trino --execute="CREATE SCHEMA hive.$schema_name WITH (location = 'hdfs://namenode/opt/hive/data/$schema_name/external/$schema_name.db');"
@@ -794,16 +784,15 @@ createSchemaWithTrino() {
 dropSchemaWithTrino() {
   schema_name=$1
   use_cascade=$2
-  print=$3
 
   if [ "$use_cascade" == "true" ]; then
-    if [ "$print" == "true" ]; then
+    if [ "$PRINT_CMD" == "true" ]; then
       printCmdString "DROP SCHEMA hive.$schema_name CASCADE;"
     else
       docker exec -it "$TRINO_HOSTNAME" trino --execute="DROP SCHEMA hive.$schema_name CASCADE;"
     fi
   else
-    if [ "$print" == "true" ]; then
+    if [ "$PRINT_CMD" == "true" ]; then
       printCmdString "DROP SCHEMA hive.$schema_name;"
     else
       docker exec -it "$TRINO_HOSTNAME" trino --execute="DROP SCHEMA hive.$schema_name;"
@@ -927,7 +916,7 @@ retryOperationIfNeeded() {
   cmd=$2
   expMsg=$3
   expFailure=$4
-  notExpMsg=$5
+  msgNotPresent=$5
 
   result=""
 
@@ -937,6 +926,7 @@ retryOperationIfNeeded() {
     result="succeeded"
   fi
 
+  echo ""
   echo "- INFO: Some wait time might be needed for the policy update to get picked up. Retry a few times if needed."
   echo ""
 
@@ -961,7 +951,11 @@ retryOperationIfNeeded() {
     #
     # To fix that, each method will either print the command or execute it.
     # We will call each method twice. Once with the print parameter and once without.
-    $cmd "true"
+    PRINT_CMD="true"
+    $cmd
+
+    # Restore the flag to empty.
+    PRINT_CMD=""
 
     echo ""
     echo "### Stdout- {"
@@ -975,7 +969,7 @@ retryOperationIfNeeded() {
     echo "} -Stdout ###"
     echo ""
 
-    if [ "$notExpMsg" == "true" ]; then
+    if [ "$msgNotPresent" == "true" ]; then
       # '> /dev/null' hides the grep output. Remove it to reveal the output.
       if !(grep -F "$expMsg" "$abs_path/$CURRENT_REPO/$TMP_FILE" > /dev/null); then
         # echo "- DEBUG: Exit code NotExp-Suc-Grep: $?"

--- a/trino-hms-hdfs-ranger/tests/spark/1_test_spark_no_hdfs_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/1_test_spark_no_hdfs_perms.sh
@@ -18,4 +18,4 @@ failMsg='Permission denied: user=spark, access=WRITE'
 # We need to use single '' in the failMsg because it contains special characters e.g. /
 # That way it will be interpreted as a string literal and won't be expanded.
 
-retryOperationIfNeeded "$abs_path" "createSparkTable $SPARK_TABLE $HDFS_DIR" "$failMsg" "true"
+retryOperationIfNeeded "$abs_path" "createSparkTable $SPARK_TABLE $HDFS_DIR $DEFAULT_DB" "$failMsg" "true"

--- a/trino-hms-hdfs-ranger/tests/spark/2_test_spark_hdfs_perms_no_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/2_test_spark_hdfs_perms_no_hive_perms.sh
@@ -26,4 +26,4 @@ echo "- INFO: Ranger policies updated."
 
 failMsg="Permission denied: user [spark] does not have [CREATE] privilege on [default/$SPARK_TABLE]"
 
-retryOperationIfNeeded "$abs_path" "createSparkTable $SPARK_TABLE $HDFS_DIR" "$failMsg" "true"
+retryOperationIfNeeded "$abs_path" "createSparkTable $SPARK_TABLE $HDFS_DIR $DEFAULT_DB" "$failMsg" "true"

--- a/trino-hms-hdfs-ranger/tests/spark/3_test_spark_hdfs_hive_all.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/3_test_spark_hdfs_hive_all.sh
@@ -21,7 +21,7 @@ echo "- INFO: [create] should succeed."
 # then check that message doesn't contain Permission denied.
 notExpMsg="Permission denied"
 
-retryOperationIfNeeded "$abs_path" "createSparkTable $SPARK_TABLE $HDFS_DIR" "$notExpMsg" "false" "true"
+retryOperationIfNeeded "$abs_path" "createSparkTable $SPARK_TABLE $HDFS_DIR $DEFAULT_DB" "$notExpMsg" "false" "true"
 
 echo ""
 echo "- INFO: Create partitioned table"

--- a/trino-hms-hdfs-ranger/tests/spark/4_test_spark_only_select_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/4_test_spark_only_select_perm.sh
@@ -20,7 +20,7 @@ echo "- INFO: [select] should succeed."
 
 successMsg="|  1, dog|"
 
-retryOperationIfNeeded "$abs_path" "selectDataFromSparkTable $SPARK_TABLE" "$successMsg" "false"
+retryOperationIfNeeded "$abs_path" "selectDataFromSparkTable $SPARK_TABLE $DEFAULT_DB" "$successMsg" "false"
 
 echo ""
 echo "- INFO: Rename table"
@@ -28,7 +28,7 @@ echo "- INFO: [alter] should fail."
 
 failMsg="Permission denied: user [spark] does not have [ALTER] privilege on [default/$SPARK_TABLE]"
 
-retryOperationIfNeeded "$abs_path" "alterSparkTable $SPARK_TABLE $NEW_SPARK_TABLE_NAME" "$failMsg" "true"
+retryOperationIfNeeded "$abs_path" "alterSparkTable $SPARK_TABLE $NEW_SPARK_TABLE_NAME $DEFAULT_DB" "$failMsg" "true"
 
 echo ""
 echo "- INFO: Drop partition"

--- a/trino-hms-hdfs-ranger/tests/spark/5_test_spark_select_alter_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/5_test_spark_select_alter_perm.sh
@@ -20,7 +20,7 @@ echo "- INFO: [alter] should now succeed."
 
 successMsg="org.apache.spark.sql.DataFrame = []"
 
-retryOperationIfNeeded "$abs_path" "alterSparkTable $SPARK_TABLE $NEW_SPARK_TABLE_NAME" "$successMsg" "false"
+retryOperationIfNeeded "$abs_path" "alterSparkTable $SPARK_TABLE $NEW_SPARK_TABLE_NAME $DEFAULT_DB" "$successMsg" "false"
 
 echo ""
 echo "- INFO: Drop partition"

--- a/trino-hms-hdfs-ranger/tests/spark/6_test_spark_no_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/6_test_spark_no_drop_table_perm.sh
@@ -14,4 +14,4 @@ echo "- INFO: [drop] should fail."
 
 failMsg="Permission denied: user [spark] does not have [DROP] privilege on [default/$NEW_SPARK_TABLE_NAME]"
 
-retryOperationIfNeeded "$abs_path" "dropSparkTable $NEW_SPARK_TABLE_NAME" "$failMsg" "true"
+retryOperationIfNeeded "$abs_path" "dropSparkTable $NEW_SPARK_TABLE_NAME $DEFAULT_DB" "$failMsg" "true"

--- a/trino-hms-hdfs-ranger/tests/spark/7_test_spark_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/7_test_spark_drop_table_perm.sh
@@ -16,4 +16,4 @@ echo "- INFO: [drop] should succeed."
 
 successMsg="org.apache.spark.sql.DataFrame = []"
 
-retryOperationIfNeeded "$abs_path" "dropSparkTable $NEW_SPARK_TABLE_NAME" "$successMsg" "false"
+retryOperationIfNeeded "$abs_path" "dropSparkTable $NEW_SPARK_TABLE_NAME $DEFAULT_DB" "$successMsg" "false"

--- a/trino-hms-hdfs-ranger/tests/spark/database/3_drop_database_no_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/3_drop_database_no_perms.sh
@@ -14,6 +14,6 @@ echo ""
 
 failMsg="Permission denied: user [spark] does not have [DROP] privilege on [$EXTERNAL_DB]"
 
-retryOperationIfNeeded "$abs_path" "dropDatabaseWithSpark $EXTERNAL_DB" "$failMsg" "true"
+retryOperationIfNeeded "$abs_path" "dropDatabaseWithSpark $EXTERNAL_DB false" "$failMsg" "true"
 
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/6_drop_database_no_cascade.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/6_drop_database_no_cascade.sh
@@ -17,4 +17,4 @@ echo "- INFO: Dropping a DB that's not empty, without using CASCADE, should fail
 # This is error message for Spark 3.3.2
 failMsg="Cannot drop a non-empty database: $EXTERNAL_DB. Use CASCADE option to drop a non-empty database."
 
-retryOperationIfNeeded "$abs_path" "dropDatabaseWithSpark $EXTERNAL_DB" "$failMsg" "true"
+retryOperationIfNeeded "$abs_path" "dropDatabaseWithSpark $EXTERNAL_DB false" "$failMsg" "true"

--- a/trino-hms-hdfs-ranger/tests/test_hdfs_data_creation.sh
+++ b/trino-hms-hdfs-ranger/tests/test_hdfs_data_creation.sh
@@ -18,7 +18,22 @@ echo ""
 echo "- INFO: HDFS user hadoop, should be able to create data with ranger default policies."
 echo ""
 
-createHdfsDir "$HDFS_DIR"
-createHdfsFile "$HDFS_DIR"
+# Print cmd first.
+createHdfsDir "$HDFS_DIR" "true"
+
+if createHdfsDir "$HDFS_DIR"; then
+  # Print cmd first.
+  addHdfsTestFileUnderDir "$HDFS_DIR" "true"
+  if addHdfsTestFileUnderDir "$HDFS_DIR"; then
+    echo ""
+    echo "- RESULT: HDFS test data creation succeeded."
+  else
+    echo ""
+    echo "- RESULT: HDFS test data creation failed."
+  fi
+else
+  echo ""
+  echo "- RESULT: HDFS test data creation failed."
+fi
 
 createHdfsDir "$HIVE_WAREHOUSE_DIR"

--- a/trino-hms-hdfs-ranger/tests/test_hdfs_data_creation.sh
+++ b/trino-hms-hdfs-ranger/tests/test_hdfs_data_creation.sh
@@ -18,22 +18,10 @@ echo ""
 echo "- INFO: HDFS user hadoop, should be able to create data with ranger default policies."
 echo ""
 
-# Print cmd first.
-createHdfsDir "$HDFS_DIR" "true"
+notExpMsg="Permission denied"
+retryOperationIfNeeded "$abs_path" "createHdfsDir $HDFS_DIR" "$notExpMsg" "false" "true"
 
-if createHdfsDir "$HDFS_DIR"; then
-  # Print cmd first.
-  addHdfsTestFileUnderDir "$HDFS_DIR" "true"
-  if addHdfsTestFileUnderDir "$HDFS_DIR"; then
-    echo ""
-    echo "- RESULT: HDFS test data creation succeeded."
-  else
-    echo ""
-    echo "- RESULT: HDFS test data creation failed."
-  fi
-else
-  echo ""
-  echo "- RESULT: HDFS test data creation failed."
-fi
+notExpMsg="Permission denied"
+retryOperationIfNeeded "$abs_path" "addHdfsTestFileUnderDir $HDFS_DIR" "$notExpMsg" "false" "true"
 
 createHdfsDir "$HIVE_WAREHOUSE_DIR"

--- a/trino-hms-hdfs-ranger/tests/test_hdfs_data_creation.sh
+++ b/trino-hms-hdfs-ranger/tests/test_hdfs_data_creation.sh
@@ -22,6 +22,7 @@ notExpMsg="Permission denied"
 retryOperationIfNeeded "$abs_path" "createHdfsDir $HDFS_DIR" "$notExpMsg" "false" "true"
 
 notExpMsg="Permission denied"
-retryOperationIfNeeded "$abs_path" "addHdfsTestFileUnderDir $HDFS_DIR" "$notExpMsg" "false" "true"
+retryOperationIfNeeded "$abs_path" "createHdfsFile $HDFS_DIR" "$notExpMsg" "false" "true"
 
-createHdfsDir "$HIVE_WAREHOUSE_DIR"
+notExpMsg="Permission denied"
+retryOperationIfNeeded "$abs_path" "createHdfsDir $HIVE_WAREHOUSE_DIR" "$notExpMsg" "false" "true"

--- a/trino-hms-hdfs-ranger/tests/test_hive_url_policies.sh
+++ b/trino-hms-hdfs-ranger/tests/test_hive_url_policies.sh
@@ -13,7 +13,7 @@ if [ "$prepare_env" == "true" ]; then
   ./docker/stop_docker_env.sh "$abs_path"
   ./setup/setup_docker_env.sh "$abs_path"
   ./docker/start_docker_env.sh "$abs_path" "true"
-  createHdfsDir "$HIVE_WAREHOUSE_DIR"
+  createHdfsDir "$HIVE_WAREHOUSE_DIR" # This isn't called with retryOperationIfNeeded and it won't print any descriptive output.
 fi
 
 if [ "$component" == "spark" ]; then

--- a/trino-hms-hdfs-ranger/tests/trino/1_test_trino_no_hdfs_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/1_test_trino_no_hdfs_perms.sh
@@ -15,4 +15,4 @@ echo ""
 # Failure due to lack of HDFS permissions.
 failMsg="Permission denied: user [postgres] does not have [ALL] privilege on" # [hdfs://namenode:8020/$HDFS_DIR]"
 
-retryOperationIfNeeded "$abs_path" "createTrinoTable $TRINO_TABLE $HDFS_DIR" "$failMsg" "true"
+retryOperationIfNeeded "$abs_path" "createTrinoTable $TRINO_TABLE $HDFS_DIR $DEFAULT_DB" "$failMsg" "true"

--- a/trino-hms-hdfs-ranger/tests/trino/2_test_trino_hdfs_perms_no_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/2_test_trino_hdfs_perms_no_hive_perms.sh
@@ -28,4 +28,4 @@ echo "- INFO: Ranger policies updated."
 
 failMsg="Permission denied: user [postgres] does not have [CREATE] privilege on"
 
-retryOperationIfNeeded "$abs_path" "createTrinoTable $TRINO_TABLE $HDFS_DIR" "$failMsg" "true"
+retryOperationIfNeeded "$abs_path" "createTrinoTable $TRINO_TABLE $HDFS_DIR $DEFAULT_DB" "$failMsg" "true"

--- a/trino-hms-hdfs-ranger/tests/trino/3_test_trino_hdfs_hive_all.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/3_test_trino_hdfs_hive_all.sh
@@ -25,4 +25,5 @@ waitForPoliciesUpdate
 echo ""
 echo "- INFO: Create $TRINO_TABLE table non-managed by Hive."
 successMsg="CREATE TABLE"
-retryOperationIfNeeded "$abs_path" "createTrinoTable $TRINO_TABLE $HDFS_DIR" "$successMsg" "false"
+
+retryOperationIfNeeded "$abs_path" "createTrinoTable $TRINO_TABLE $HDFS_DIR $DEFAULT_DB" "$successMsg" "false"

--- a/trino-hms-hdfs-ranger/tests/trino/4_test_trino_only_select_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/4_test_trino_only_select_perm.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# For this test, prerequisite is that 3_test_trino_hdfs_hive_all.sh is run.
-
 source "./testlib.sh"
 
 set -e
@@ -17,7 +15,8 @@ echo ""
 echo "- INFO: Select from $TRINO_TABLE table."
 echo "- INFO: [select] should succeed."
 successMsg="\"1\",\" dog\""
-retryOperationIfNeeded "$abs_path" "selectDataFromTrinoTable $TRINO_TABLE" "$successMsg" "false"
+
+retryOperationIfNeeded "$abs_path" "selectDataFromTrinoTable $TRINO_TABLE $DEFAULT_DB" "$successMsg" "false"
 
 echo ""
 echo "- INFO: Insert into $TRINO_TABLE table."
@@ -30,7 +29,8 @@ echo ""
 echo "- INFO: Rename $TRINO_TABLE table."
 echo "- INFO: [alter] should fail."
 failMsg="Permission denied: user [postgres] does not have [ALTER] privilege"
-retryOperationIfNeeded "$abs_path" "alterTrinoTable $TRINO_TABLE $NEW_TRINO_TABLE_NAME" "$failMsg" "true"
+
+retryOperationIfNeeded "$abs_path" "alterTrinoTable $TRINO_TABLE $NEW_TRINO_TABLE_NAME $DEFAULT_DB" "$failMsg" "true"
 
 echo ""
 echo "- INFO: Insert into $TABLE_ANIMALS table."

--- a/trino-hms-hdfs-ranger/tests/trino/5_test_trino_select_alter_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/5_test_trino_select_alter_perm.sh
@@ -31,7 +31,8 @@ echo ""
 echo "- INFO: Rename table $TRINO_TABLE."
 echo "- INFO: [alter] should now succeed."
 successMsg="RENAME TABLE"
-retryOperationIfNeeded "$abs_path" "alterTrinoTable $TRINO_TABLE $NEW_TRINO_TABLE_NAME" "$successMsg" "false"
+
+retryOperationIfNeeded "$abs_path" "alterTrinoTable $TRINO_TABLE $NEW_TRINO_TABLE_NAME $DEFAULT_DB" "$successMsg" "false"
 
 echo ""
 echo "- INFO: Insert into $TABLE_ANIMALS table."

--- a/trino-hms-hdfs-ranger/tests/trino/6_test_trino_no_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/6_test_trino_no_drop_table_perm.sh
@@ -16,5 +16,5 @@ echo "- INFO: [drop] should fail."
 # Thanks to xBis7 for investigation, it was found that permission denied exception is swallowed and a new exception is thrown with a different message.
 # This seems to done for better messaging experience, but it is misleading.
 # More info could be found on the link https://github.com/G-Research/gr-oss/issues/551#issuecomment-1994240651.
-failMsg="The following metastore delete operations failed: drop table default.$NEW_TRINO_TABLE_NAME"
-retryOperationIfNeeded "$abs_path" "dropTrinoTable $NEW_TRINO_TABLE_NAME" "$failMsg" "true"
+failMsg="The following metastore delete operations failed: drop table $DEFAULT_DB.$NEW_TRINO_TABLE_NAME"
+retryOperationIfNeeded "$abs_path" "dropTrinoTable $NEW_TRINO_TABLE_NAME $DEFAULT_DB" "$failMsg" "true"

--- a/trino-hms-hdfs-ranger/tests/trino/7_test_trino_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/7_test_trino_drop_table_perm.sh
@@ -16,4 +16,4 @@ echo "- INFO: [drop] should succeed."
 
 successMsg="DROP TABLE"
 
-retryOperationIfNeeded "$abs_path" "dropTrinoTable $NEW_TRINO_TABLE_NAME" "$successMsg" "false"
+retryOperationIfNeeded "$abs_path" "dropTrinoTable $NEW_TRINO_TABLE_NAME $DEFAULT_DB" "$successMsg" "false"

--- a/trino-hms-hdfs-ranger/tests/trino/schema/3_drop_schema_no_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/3_drop_schema_no_perms.sh
@@ -13,6 +13,6 @@ echo ""
 
 failMsg="Permission denied: user [postgres] does not have [DROP] privilege on [$EXTERNAL_DB]"
 
-retryOperationIfNeeded "$abs_path" "dropSchemaWithTrino $EXTERNAL_DB" "$failMsg" "true"
+retryOperationIfNeeded "$abs_path" "dropSchemaWithTrino $EXTERNAL_DB false" "$failMsg" "true"
 
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/6_drop_schema_no_cascade.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/6_drop_schema_no_cascade.sh
@@ -13,4 +13,4 @@ echo "- INFO: Dropping a DB that's not empty, without using CASCADE, should fail
 
 failMsg="Cannot drop non-empty schema '$EXTERNAL_DB'"
 
-retryOperationIfNeeded "$abs_path" "dropSchemaWithTrino $EXTERNAL_DB" "$failMsg" "true"
+retryOperationIfNeeded "$abs_path" "dropSchemaWithTrino $EXTERNAL_DB false" "$failMsg" "true"


### PR DESCRIPTION
https://github.com/G-Research/gr-oss/issues/625

This is improving the output of the `retryOperationIfNeeded` method. Each method execution is redirected to a file using the `tee` command. The `tee` command gets the output and prints it to the stdout while also writing it to a file.

I've added an echo with the current command
```
Command being run: -- '...'
```

and I've also wrapped the stdout like this, so that it's easier to spot
```
### Stdout- {

...

} -Stdout ###
```

Example output

```
Command being run: -- 'spark.read.text("hdfs://namenode:8020/test").write.option("path", "hdfs://namenode/opt/hive/data").mode("overwrite").format("csv").saveAsTable("poc_db.spark_test_table")'


### Stdout- {

Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
24/03/29 16:16:37 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Spark context Web UI available at http://spark-master:4040
Spark context available as 'sc' (master = spark://spark-master:7077, app id = app-20240329161637-0005).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.3.2
      /_/
         
Using Scala version 2.12.15 (OpenJDK 64-Bit Server VM, Java 11.0.22)
Type in expressions to have them evaluated.
Type :help for more information.

scala> Hive Session ID = 582b5268-b4f7-4c27-8618-6eed1dbd59a1
24/03/29 16:16:44 WARN HiveExternalCatalog: Couldn't find corresponding Hive SerDe for data source provider csv. Persisting data source table `poc_db`.`spark_test_table` into Hive metastore in Spark SQL specific format, which is NOT compatible with Hive.
org.apache.spark.sql.AnalysisException: org.apache.hadoop.hive.ql.metadata.HiveException: MetaException(message:Permission denied: user [spark] does not have [CREATE] privilege on [poc_db/spark_test_table])
  at org.apache.spark.sql.hive.HiveExternalCatalog.withClient(HiveExternalCatalog.scala:110)
...
...
...
...
...
...
...
...
...
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
  at java.base/java.lang.reflect.Method.invoke(Unknown Source)
  at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.invoke(RetryingMetaStoreClient.java:212)
  at com.sun.proxy.$Proxy40.createTable(Unknown Source)
  at org.apache.hadoop.hive.ql.metadata.Hive.createTable(Hive.java:928)
  ... 93 more

scala> :quit


} -Stdout ###
```

I've run all tests for both Spark and Trino multiple times to make sure nothing is broken.

The tricky part has been printing the command. If we add the print inside every method that runs the command, then the print will also get stored in the tmp file that we are checking for the expected output message. Some times the expected output is part of the command and we end up with unexpected failures.