### PR TITLE
Fix Hive build

### DIFF
--- a/trino-hms-hdfs-ranger/testlib.sh
+++ b/trino-hms-hdfs-ranger/testlib.sh
@@ -24,7 +24,7 @@ configureHiveVersion() {
     echo "Configuring project for Hive 4."
     echo ""
     HIVE_BRANCH="hive4-latest"
-    HIVE_BUILD="4.0.0-beta-2-SNAPSHOT"
+    HIVE_BUILD="4.0.0"
     RANGER_BRANCH="ranger-docker-hive4"
   else
     echo ""


### PR DESCRIPTION
Change of `HIVE_RUNNER_VERSION` in `.env` file in Hive repo caused `docker-setup-helper-scripts` to be unable to run tests with Hive 4 version.

Here is the diff:
```
diff --git a/packaging/src/standalone-metastore/compose/hive-metastore-ranger/.env b/packaging/src/standalone-metastore/compose/hive-metastore-ranger/.env
--- a/packaging/src/standalone-metastore/compose/hive-metastore-ranger/.env	(revision 350f6a5261fa0a421935bdf6f57fbe70cd2bb1e2)
+++ b/packaging/src/standalone-metastore/compose/hive-metastore-ranger/.env	(revision 5f2590f2942ce7fe54bc3bc271cdba0f5d50db4c)
@@ -16,5 +16,5 @@
 #
 
 HIVE_IMAGE=apache/hive
-HIVE_RUNNER_VERSION=4.0.0-beta-2-SNAPSHOT
+HIVE_RUNNER_VERSION=4.0.0
 HIVE_RUNNER_IMAGE=apache/hive
```

This change is simply setting the same Hive build as in Hive repo.