### PR TITLE
Fix Trino latest image JVM issue

### DIFF
--- a/compose/trino/etc/jvm.config
+++ b/compose/trino/etc/jvm.config
@@ -15,5 +15,4 @@
 # Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
 -XX:+UnlockDiagnosticVMOptions
 -XX:GCLockerRetryAllocationCount=32
--XX:+UnlockDiagnosticVMOptions
 -XX:G1NumCollectionsKeepPinned=10000000

--- a/compose/trino/etc/jvm.config
+++ b/compose/trino/etc/jvm.config
@@ -15,3 +15,5 @@
 # Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
 -XX:+UnlockDiagnosticVMOptions
 -XX:GCLockerRetryAllocationCount=32
+-XX:+UnlockDiagnosticVMOptions
+-XX:G1NumCollectionsKeepPinned=10000000


### PR DESCRIPTION
#### Summary
Goal of this PR is to fix issue of Trino coordinator container exiting prematurely. This is because of the latest Trino image. Inside Docker compose file, Trino image is used as trinodb/trino:latest. It might be a good idea to lock version at one point.

#### Description
After cleaning up and rebuilding everything on EC2 instance, Trino coordinator could not start. These are Trino coordinator container logs:
```
ubuntu@ip-172-31-40-99:~/docker-setup-helper-scripts/trino-hms-hdfs-ranger$ docker logs trino-coordinator-1
+ launcher_opts=(--etc-dir /etc/trino)
+ grep -s -q node.id /etc/trino/node.properties
+ launcher_opts+=("-Dnode.id=${HOSTNAME}")
+ exec /usr/lib/trino/bin/launcher run --etc-dir /etc/trino -Dnode.id=trino-coordinator
ERROR: Trino requires -XX:+UnlockDiagnosticVMOptions -XX:G1NumCollectionsKeepPinned=10000000 on Java versions lower than 22.0.2 due to JDK-8329528
```

After adding:
```
-XX:+UnlockDiagnosticVMOptions 
-XX:G1NumCollectionsKeepPinned=10000000
```
to jvm.config file located at compose/trino/etc, Trino coordinator started without issues.

#### Steps to reproduce
```
docker stop ($docker ps -a -q)
docker system prune -a --volumes
setup/get_or_update_projects.sh $HOME mladjan-gadzic xBis7
setup/build_projects.sh $HOME all $JAVA_HOME
setup/setup_for_trino_spark_testing.sh $HOME
```