### PR TITLE
Initialize the 'externalCatalog' object in advance, when needed to avoid defaultdb SELECT error

### DIFF
--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_1.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_1.sh
@@ -25,14 +25,15 @@ updateHiveDbAllPolicy ""
 
 # 1st parameter: permissions
 # 2nd parameter: deny permissions if necessary
-updateHiveDefaultDbPolicy "select:$SPARK_USER1"
+# updateHiveDefaultDbPolicy "select:$SPARK_USER1"
+updateHiveDefaultDbPolicy ""
 
 # 1st parameter: comma-separated list of URLs
 # 2nd parameter: permissions
 # 3rd parameter: deny permissions if necessary
 updateHiveUrlPolicy ""
 
-waitForPoliciesUpdate
+# waitForPoliciesUpdate
 
 # 'data/projects' can be replaced by '$EXTERNAL_HIVE_DB_PATH'
 command="spark.sql(\"create database gross_test location '/data/projects/gross_test/gross_test.db'\")"
@@ -43,4 +44,4 @@ expectedErrorMsg="Permission denied: user [$SPARK_USER1] does not have [CREATE] 
 # 2nd parameter: the command to be executed
 # 3rd parameter: 'shouldPass' if the command should succeed and 'shouldFail' if the command should fail
 # 4th parameter: the expected error message if the previous parameter is 'shouldFail'
-runSpark "$SPARK_USER1" "$command" "shouldFail" "$expectedErrorMsg"
+runSpark "$SPARK_USER1" "$command" "shouldFail" "$expectedErrorMsg" "catalogObjectInit"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_1.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_1.sh
@@ -25,7 +25,6 @@ updateHiveDbAllPolicy ""
 
 # 1st parameter: permissions
 # 2nd parameter: deny permissions if necessary
-# updateHiveDefaultDbPolicy "select:$SPARK_USER1"
 updateHiveDefaultDbPolicy ""
 
 # 1st parameter: comma-separated list of URLs
@@ -33,7 +32,7 @@ updateHiveDefaultDbPolicy ""
 # 3rd parameter: deny permissions if necessary
 updateHiveUrlPolicy ""
 
-# waitForPoliciesUpdate
+waitForPoliciesUpdate
 
 # 'data/projects' can be replaced by '$EXTERNAL_HIVE_DB_PATH'
 command="spark.sql(\"create database gross_test location '/data/projects/gross_test/gross_test.db'\")"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_2.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_2.sh
@@ -15,7 +15,7 @@ updateHdfsPathPolicy ""
 updateHiveDbAllPolicy "gross_test" "alter,create,drop,index,lock,select,update:$SPARK_USER1"
 
 # It's the same as in the previous test.
-updateHiveDefaultDbPolicy "select:$SPARK_USER1"
+updateHiveDefaultDbPolicy ""
 
 # It's the same as in the previous test.
 updateHiveUrlPolicy ""
@@ -32,4 +32,4 @@ expectedErrorMsg="Permission denied: user [$SPARK_USER1] does not have [WRITE] p
 # 2nd parameter: the command to be executed
 # 3rd parameter: 'shouldPass' if the command should succeed and 'shouldFail' if the command should fail
 # 4th parameter: the expected error message if the previous parameter is 'shouldFail'
-runSpark "$SPARK_USER1" "$command" "shouldFail" "$expectedErrorMsg"
+runSpark "$SPARK_USER1" "$command" "shouldFail" "$expectedErrorMsg" "catalogObjectInit"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_3.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_3.sh
@@ -16,7 +16,7 @@ updateHdfsPathPolicy "/*" "read,write,execute:$SPARK_USER1"
 updateHiveDbAllPolicy "gross_test" "alter,create,drop,index,lock,select,update:$SPARK_USER1"
 
 # It's the same as in the previous test.
-updateHiveDefaultDbPolicy "select:$SPARK_USER1"
+updateHiveDefaultDbPolicy ""
 
 updateHiveUrlPolicy "hdfs://$NAMENODE_NAME/data/projects/gross_test" "read,write:$SPARK_USER1"
 
@@ -29,4 +29,4 @@ command="spark.sql(\"create database gross_test location '/data/projects/gross_t
 # 2nd parameter: the command to be executed
 # 3rd parameter: 'shouldPass' if the command should succeed and 'shouldFail' if the command should fail
 # 4th parameter: the expected error message if the previous parameter is 'shouldFail'
-runSpark "$SPARK_USER1" "$command" "shouldPass"
+runSpark "$SPARK_USER1" "$command" "shouldPass" "noOutputCheck" "catalogObjectInit"


### PR DESCRIPTION
https://github.com/G-Research/gr-oss/issues/758

The first time that we are running a command on an external db in a `spark-shell` instance, the `externalCatalog` object has to be initialized.

The initialization checks if the default db exists and if it needs to be created. That requires SELECT access on the default db and for that reason we might be getting a defaultdb SELECT error on an external db operation.

The initialization needs to happen once for every new `spark-shell` instance.

To workaround this, we need to
* provide select access 
* start a new `spark-shell` instance
* run any command on the external catalog
* remove the select access
* run the test command on the same `spark-shell`

We need a shell script running in the background and making the select updates while the test scala file runs on the `spark-shell` and executes the commands.

To achieve synchronization between the two and let them know when to execute what, I've used tmp files to signal the two processes.

The flow goes like this
* Start the shell method in the background
* Submit the scala file in the `spark-shell`
  * This is blocked and waits for a signal file that the initial select update has been made
* The scala file is blocked and waiting, the shell method starts first
* The shell method 
  * updates the defaultdb policies and provides select access
  * creates the signal file to let the scala file know to start the execution
  * waits until a signal file is created by the scala file
* The scala file
  * waits for the predefined interval to make sure that the policies are updated
  * runs `show databases` to initialize the object
  * creates the signal file to let the shell method know to remove the select access
  * waits until the shell method has created a signal file that the update has been made
* The shell method
  * picks up that there is a signal file to remove the select access
  * removes the select access
  * creates the signal file that the update has been made
  * FINISHES
* The scala file
  * picks up that there is a signal file that the update has been made
  * waits for the predefined interval to make sure that the policies are updated
  * FINISHES

The scala file continues with the rest of the test execution, same as before.