### PR TITLE
Cleanup Trino tests

### DIFF
--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_11.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_11.sh
@@ -18,7 +18,7 @@ updateHiveDbAllPolicy "gross_test" "alter,create,drop,index,lock,select,update:$
 # It's the same as in the previous test.
 updateHiveDefaultDbPolicy "select:$SPARK_USER1,$SPARK_USER2"
 
-# There is no note about Hive URL policies but as long as we update HDFS policies and add '/data/projects/gross_test'
+# BigData note: There is no note about Hive URL policies but as long as we update HDFS policies and add '/data/projects/gross_test'
 # and we are expecting the command to succeed, then we also need to add 'hdfs://$NAMENODE_NAME/data/projects/gross_test' here.
 
 # If we replace 'updateHiveUrlPolicy "hdfs://$NAMENODE_NAME/$HIVE_WAREHOUSE_DIR/gross_test.db,hdfs://$NAMENODE_NAME/data/projects/gross_test" "read,write:$SPARK_USER1"'
@@ -62,7 +62,7 @@ runSpark "$SPARK_USER1" "$command" "shouldPass" "$expectedOutput"
 expectedOutput="|Location                    |hdfs://$NAMENODE_NAME/data/projects/gross_test/test2"
 runSpark "$SPARK_USER1" "$command" "shouldPass" "$expectedOutput"
 
-# Change directory permissions so that another user won't be able to execute on HDFS paths without a Ranger policy. 
+# BigData note: Change directory permissions so that another user won't be able to execute on HDFS paths without a Ranger policy. 
 changeHdfsDirPermissions "data/projects/gross_test" 750
 
 # Run commands as user2.

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_8.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_8.sh
@@ -51,7 +51,7 @@ command="spark.sql(\"describe gross_test.test\").show(false)"
 
 runSpark "$SPARK_USER2" "$command" "shouldPass"
 
-# User1 created the directory and the default permissions are 755.
+# BigData note: User1 created the directory and the default permissions are 755.
 # Change permissions here to get an HDFS POSIX permissions error and
 # check that creating a Ranger policy fixes it.
 changeHdfsDirPermissions "$HIVE_WAREHOUSE_DIR/gross_test.db" 750
@@ -71,7 +71,7 @@ runSpark "$SPARK_USER2" "$command" "shouldPass"
 
 command="spark.sql(\"insert into gross_test.test values (4, 'Austin')\")"
 
-# Because we changed the directory POSIX permissions.
+# BigData note: Because we changed the directory POSIX permissions.
 expectedErrorMsg="Permission denied: user=$SPARK_USER2, access=EXECUTE, inode=\"/$HIVE_WAREHOUSE_DIR/gross_test.db\":"
 
 runSpark "$SPARK_USER2" "$command" "shouldFail" "$expectedErrorMsg"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_8.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/spark/test_8.sh
@@ -52,7 +52,7 @@ command="spark.sql(\"describe gross_test.test\").show(false)"
 runSpark "$SPARK_USER2" "$command" "shouldPass"
 
 # User1 created the directory and the default permissions are 755.
-# Change permissions here to get an HDFS ACLs error and
+# Change permissions here to get an HDFS POSIX permissions error and
 # check that creating a Ranger policy fixes it.
 changeHdfsDirPermissions "$HIVE_WAREHOUSE_DIR/gross_test.db" 750
 
@@ -71,7 +71,7 @@ runSpark "$SPARK_USER2" "$command" "shouldPass"
 
 command="spark.sql(\"insert into gross_test.test values (4, 'Austin')\")"
 
-# Because we changed the directory ACLs.
+# Because we changed the directory POSIX permissions.
 expectedErrorMsg="Permission denied: user=$SPARK_USER2, access=EXECUTE, inode=\"/$HIVE_WAREHOUSE_DIR/gross_test.db\":"
 
 runSpark "$SPARK_USER2" "$command" "shouldFail" "$expectedErrorMsg"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/test.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/test.sh
@@ -24,6 +24,10 @@ fi
 # createHdfsDir uses the '-p' option. If the directory already exists, there won't be an error.
 createHdfsDir "$HIVE_GROSS_DB_TEST_DIR"
 
+# BigData note: Create the tmp directory and provide world access to it so that Trino can use it.
+createHdfsDir "tmp"
+changeHdfsDirPermissions "tmp" 777
+
 ./big-data-c3-tests/trino-spark-tests/spark/test_spark.sh "$abs_path"
 
 # Cleanup any data leftovers from the spark tests.

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_10.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_10.sh
@@ -60,12 +60,12 @@ expectedMsg=""
 
 runTrino "$TRINO_USER2" "$command" "shouldPass" "$expectedMsg"
 
-# Change permissions here to get an HDFS ACLs error and
+# Change permissions here to get an HDFS POSIX permissions error and
 # check that creating a Ranger policy fixes it.
 changeHdfsDirPermissions "$HIVE_WAREHOUSE_DIR/gross_test.db" 700
 
 command="select * from $TRINO_HIVE_SCHEMA.gross_test.test"
-# This is the expected error according to the BigData notes for ACL access drwx------.
+# This is the expected error according to the BigData notes for POSIX permission access drwx------.
 # expectedMsg="Permission denied: user=$TRINO_USER2, access=EXECUTE, inode=\"/$HIVE_WAREHOUSE_DIR/gross_test.db\":"
 expectedMsg="Failed to list directory: hdfs://$NAMENODE_NAME/$HIVE_WAREHOUSE_DIR/gross_test.db/test"
 
@@ -79,7 +79,7 @@ runTrino "$TRINO_USER2" "$command" "shouldFail" "$expectedMsg"
 # But after the update, select is expected to work.
 # If we don't include user2, then nothing will change.
 
-# Update the HDFS permissions to resolve the ACL execute error.
+# Update the HDFS permissions to resolve the POSIX permission execute error.
 updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1,$TRINO_USER2"
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_10.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_10.sh
@@ -60,18 +60,18 @@ expectedMsg=""
 
 runTrino "$TRINO_USER2" "$command" "shouldPass" "$expectedMsg"
 
-# Change permissions here to get an HDFS POSIX permissions error and
+# BigData note: Change permissions here to get an HDFS POSIX permissions error and
 # check that creating a Ranger policy fixes it.
 changeHdfsDirPermissions "$HIVE_WAREHOUSE_DIR/gross_test.db" 700
 
 command="select * from $TRINO_HIVE_SCHEMA.gross_test.test"
-# This is the expected error according to the BigData notes for POSIX permission access drwx------.
+# BigData note: This is the expected error according to the notes for POSIX permission access drwx------.
 # expectedMsg="Permission denied: user=$TRINO_USER2, access=EXECUTE, inode=\"/$HIVE_WAREHOUSE_DIR/gross_test.db\":"
 expectedMsg="Failed to list directory: hdfs://$NAMENODE_NAME/$HIVE_WAREHOUSE_DIR/gross_test.db/test"
 
 runTrino "$TRINO_USER2" "$command" "shouldFail" "$expectedMsg"
 
-# In the BigData notes there is a screenshot updating the policies for the 2nd user,
+# BigData note: In the notes there is a screenshot updating the policies for the 2nd user,
 # but the user isn't part of the policy update. Based on the screenshot, the policies should look like this
 #
 # updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_10.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_10.sh
@@ -74,10 +74,10 @@ runTrino "$TRINO_USER2" "$command" "shouldFail" "$expectedMsg"
 # In the BigData notes there is a screenshot updating the policies for the 2nd user,
 # but the user isn't part of the policy update. Based on the screenshot, the policies should look like this
 #
-# updateHdfsPathPolicy "/*,/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
+# updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
 #
 # But after the update, select is expected to work.
-# If we don't include user 2, then nothing will change.
+# If we don't include user2, then nothing will change.
 
 # Update the HDFS permissions to resolve the ACL execute error.
 updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1,$TRINO_USER2"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_10.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_10.sh
@@ -11,7 +11,7 @@ echo "Create a managed table and attempt to access it as a different user"
 echo ""
 
 # It's the same as in the previous test.
-updateHdfsPathPolicy "/*,/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
+updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
 
 # It's the same as in the previous test.
 updateHiveDbAllPolicy "gross_test" "alter,create,drop,index,lock,select,update:$TRINO_USER1"
@@ -80,7 +80,7 @@ runTrino "$TRINO_USER2" "$command" "shouldFail" "$expectedMsg"
 # If we don't include user 2, then nothing will change.
 
 # Update the HDFS permissions to resolve the ACL execute error.
-updateHdfsPathPolicy "/*,/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1,$TRINO_USER2"
+updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1,$TRINO_USER2"
 waitForPoliciesUpdate
 
 command="select * from $TRINO_HIVE_SCHEMA.gross_test.test"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_11.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_11.sh
@@ -10,11 +10,9 @@ echo "## Test 11 ##"
 echo "Attempt various DDL operations against the managed table as a different user"
 echo ""
 
-# BigData note: There are no notes about making policy changes. But if we leave them as they are in the previous test, then user2 will have all HDFS access.
-# We are expecting that 'create table' will fail with an HDFS error which won't happen. Instead, it will fail with a metadata error.
-# "Permission denied: user [$TRINO_USER2] does not have [CREATE] privilege on [gross_test/test2]"
-
-# Remove user2.
+# BigData note: There are no notes about making policy changes.
+# That prevents the create table call below from getting the Execute error it is supposed to get.
+# So we remove HDFS access for user2 here:
 updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
 
 # BigData note: In order to get the expected errors then user2 must have select access.

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_11.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_11.sh
@@ -10,14 +10,14 @@ echo "## Test 11 ##"
 echo "Attempt various DDL operations against the managed table as a different user"
 echo ""
 
-# There are no notes about making policy changes. But if we leave them as they are in the previous test, then user2 will have all HDFS access.
+# BigData note: There are no notes about making policy changes. But if we leave them as they are in the previous test, then user2 will have all HDFS access.
 # We are expecting that 'create table' will fail with an HDFS error which won't happen. Instead, it will fail with a metadata error.
 # "Permission denied: user [$TRINO_USER2] does not have [CREATE] privilege on [gross_test/test2]"
 
 # Remove user2.
 updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
 
-# In order to get the expected errors then user2 must have select access.
+# BigData note: In order to get the expected errors then user2 must have select access.
 # The select that has been added here, isn't part of the BigData notes.
 updateHiveDbAllPolicy "gross_test" "alter,create,drop,index,lock,select,update:$TRINO_USER1/select:$TRINO_USER2"
 
@@ -31,7 +31,7 @@ waitForPoliciesUpdate
 
 # Run the commands as user2.
 command="drop table $TRINO_HIVE_SCHEMA.gross_test.test"
-# In the BigData notes, this command is expected to fail with this error. But this is a Spark error.
+# BigData note: In the notes, this command is expected to fail with this error. But this is a Spark error.
 # The Trino error for lack of DROP privileges, is different.
 
 # expectedMsg="Permission denied: user [$TRINO_USER2] does not have [DROP] privilege on [gross_test/test]"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_11.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_11.sh
@@ -15,7 +15,7 @@ echo ""
 # "Permission denied: user [$TRINO_USER2] does not have [CREATE] privilege on [gross_test/test2]"
 
 # Remove user2.
-updateHdfsPathPolicy "/*,/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
+updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
 
 # In order to get the expected errors then user2 must have select access.
 # The select that has been added here, isn't part of the BigData notes.

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_11.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_11.sh
@@ -10,7 +10,7 @@ echo "## Test 11 ##"
 echo "Attempt various DDL operations against the managed table as a different user"
 echo ""
 
-# There are no notes about making any policy changes. But if we leave them the same, then user2 will have all HDFS access.
+# There are no notes about making policy changes. But if we leave them as they are in the previous test, then user2 will have all HDFS access.
 # We are expecting that 'create table' will fail with an HDFS error which won't happen. Instead, it will fail with a metadata error.
 # "Permission denied: user [$TRINO_USER2] does not have [CREATE] privilege on [gross_test/test2]"
 

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_12.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_12.sh
@@ -76,9 +76,8 @@ expectedMsg="Error moving data files from hdfs://$NAMENODE_NAME/tmp/"
 
 # BigData note: We can see the EXECUTE error on the namenode logs but Trino swallows the original exception and throws a new one with a new message.
 #
-# 2024-07-09 12:11:56 INFO  Server:3102 - IPC Server handler 8 on default port 8020, call Call#128 Retry#0
-# org.apache.hadoop.hdfs.protocol.ClientProtocol.rename from trino-coordinator-1.rangernw:34720 / 172.19.0.14:34720:
-# org.apache.hadoop.security.AccessControlException: Permission denied: user=games, access=EXECUTE, inode="/data/projects/gross_test":hadoop:supergroup:drwx------
+# This is the error from the namenode log:
+# "org.apache.hadoop.security.AccessControlException: Permission denied: user=games, access=EXECUTE, inode="/data/projects/gross_test":hadoop:supergroup:drwx------"
 
 runTrino "$TRINO_USER2" "$command" "shouldFail" "$expectedMsg"
 
@@ -96,16 +95,13 @@ expectedMsg="Permission denied: user [$TRINO_USER2] does not have [ALTER] privil
 
 runTrino "$TRINO_USER2" "$command" "shouldFail" "$expectedMsg"
 
-# BigData note: The notes repeat the previous error
-# expectedMsg="Permission denied: user [$TRINO_USER2] does not have [ALTER] privilege on [gross_test/test2]"
-#
+# BigData note:
 # This is a 'create table' command where user2 has to create a new directory under '/data/projects'.
 # Based on the provided policies, the user doesn't have write access on '/data/projects'.
 # There should be an HDFS write error.
-updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1/read,write,execute:$TRINO_USER2"
-waitForPoliciesUpdate
-
 command="create table $TRINO_HIVE_SCHEMA.gross_test.test3 (id int, name varchar) with (external_location = 'hdfs://$NAMENODE_NAME/data/projects/squirrel/test3')"
+# BigData note: The notes repeat the previous error
+# expectedMsg="Permission denied: user [$TRINO_USER2] does not have [ALTER] privilege on [gross_test/test2]"
 expectedMsg="Permission denied: user=$TRINO_USER2, access=WRITE, inode=\"/data/projects\":"
 
 runTrino "$TRINO_USER2" "$command" "shouldFail" "$expectedMsg"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_12.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_12.sh
@@ -49,7 +49,7 @@ expectedMsg="test2"
 
 runTrino "$TRINO_USER2" "$command" "shouldPass" "$expectedMsg"
 
-# Change permissions here to get an HDFS ACLs error and
+# Change permissions here to get an HDFS POSIX permissions error and
 # check that creating a Ranger policy fixes it.
 changeHdfsDirPermissions "data/projects/gross_test" 700
 

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_12.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_12.sh
@@ -49,12 +49,12 @@ expectedMsg="test2"
 
 runTrino "$TRINO_USER2" "$command" "shouldPass" "$expectedMsg"
 
-# Change permissions here to get an HDFS POSIX permissions error and
+# BigData note: Change permissions here to get an HDFS POSIX permissions error and
 # check that creating a Ranger policy fixes it.
 changeHdfsDirPermissions "data/projects/gross_test" 700
 
 command="select * from $TRINO_HIVE_SCHEMA.gross_test.test2"
-# In the BigData notes this is failing with an EXECUTE error.
+# BigData note: In the notes this is failing with an EXECUTE error.
 # expectedMsg="Permission denied: user=$TRINO_USER2, access=EXECUTE, inode=\"/data/projects/gross_test\":"
 expectedMsg="Failed to list directory: hdfs://$NAMENODE_NAME/data/projects/gross_test/test2"
 
@@ -68,13 +68,13 @@ expectedMsg="\"1\",\"Austin\""
 
 runTrino "$TRINO_USER2" "$command" "shouldPass" "$expectedMsg"
 
-# We have updated the HDFS policies. We shouldn't still get an EXECUTE error.
+# BigData note: We have updated the HDFS policies. We shouldn't still get an EXECUTE error.
 command="insert into $TRINO_HIVE_SCHEMA.gross_test.test2 values (2, 'Fred')"
-# In the BigData notes we are getting this error.
+# BigData note: In the notes we are getting this error.
 # expectedMsg="Permission denied: user=$TRINO_USER2, access=EXECUTE, inode=\"/data/projects/gross_test\":"
 expectedMsg="Error moving data files from hdfs://$NAMENODE_NAME/tmp/"
 
-# We can see the EXECUTE error on the namenode logs but Trino swallows the original exception and throws a new one with a new message.
+# BigData note: We can see the EXECUTE error on the namenode logs but Trino swallows the original exception and throws a new one with a new message.
 #
 # 2024-07-09 12:11:56 INFO  Server:3102 - IPC Server handler 8 on default port 8020, call Call#128 Retry#0
 # org.apache.hadoop.hdfs.protocol.ClientProtocol.rename from trino-coordinator-1.rangernw:34720 / 172.19.0.14:34720:
@@ -83,7 +83,7 @@ expectedMsg="Error moving data files from hdfs://$NAMENODE_NAME/tmp/"
 runTrino "$TRINO_USER2" "$command" "shouldFail" "$expectedMsg"
 
 command="drop table $TRINO_HIVE_SCHEMA.gross_test.test2"
-# In the BigData notes, this command is expected to fail with this error. But this is a Spark error.
+# BigData note: In the notes, this command is expected to fail with this error. But this is a Spark error.
 # The Trino error for lack of DROP privileges, is different.
 
 # expectedMsg="Permission denied: user [$TRINO_USER2] does not have [DROP] privilege on [gross_test/test]"
@@ -96,7 +96,7 @@ expectedMsg="Permission denied: user [$TRINO_USER2] does not have [ALTER] privil
 
 runTrino "$TRINO_USER2" "$command" "shouldFail" "$expectedMsg"
 
-# The BigData notes repeat the previous error
+# BigData note: The notes repeat the previous error
 # expectedMsg="Permission denied: user [$TRINO_USER2] does not have [ALTER] privilege on [gross_test/test2]"
 #
 # This is a 'create table' command where user2 has to create a new directory under '/data/projects'.

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_3.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_3.sh
@@ -23,7 +23,7 @@ updateHiveUrlPolicy "hdfs://$NAMENODE_NAME/data/projects/gross_test" "read,write
 
 waitForPoliciesUpdate
 
-# Change directory permissions so that there won't be permissions to execute on HDFS paths without a Ranger policy.
+# BigData note: Change directory permissions so that there won't be permissions to execute on HDFS paths without a Ranger policy.
 changeHdfsDirPermissions "data/projects/gross_test" 750
 
 command="create schema $TRINO_HIVE_SCHEMA.gross_test with (location = 'hdfs://$NAMENODE_NAME/data/projects/gross_test/test.db')"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_5.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_5.sh
@@ -24,7 +24,7 @@ updateHiveUrlPolicy "hdfs://$NAMENODE_NAME/data/projects/gross_test" "read,write
 
 waitForPoliciesUpdate
 
-# On the BigData notes, this test fails with a 'NullPointerException'.
+# BigData note: On the notes, this test fails with a 'NullPointerException'.
 
 command="drop schema $TRINO_HIVE_SCHEMA.gross_test"
 

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_7.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_7.sh
@@ -48,7 +48,7 @@ waitForPoliciesUpdate
 
 command="create schema $TRINO_HIVE_SCHEMA.gross_test"
 
-# In the BigData notes, this is expected to fail with metadata WRITE error. But this was the expected error for the previous test.
+# BigData note: In the notes, this is expected to fail with metadata WRITE error. But this was the expected error for the previous test.
 # This test is updating both HDFS and Hive URL policies and with the updates, we shouldn't be getting any errors.
 # In addition, the next test is creating a table under this schema. It must have been a typo error on the notes.
 

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_7.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_7.sh
@@ -10,20 +10,29 @@ echo "## Test 7 ##"
 echo "Create a database using the default hive warehouse location with an HDFS Ranger Hive, URL-based policy present"
 echo ""
 
-# BigData note: In order to get the expected output, we need to provide access for the trino user
-# to the Hive Warehouse directory as well. This isn't part of the BigData notes but it must be present.
-# Either there is another HDFS policy that grants access or there is world ACL access.
-
-# Spark tests are changing the ACLs and creating the subdirectory at this part.
-# Do the same here and keep the policies the same as in the notes.
-changeHdfsDirPermissions "$HIVE_WAREHOUSE_PARENT_DIR" 755
-changeHdfsDirPermissions "$HIVE_WAREHOUSE_DIR" 755
+# BigData note: In order to get the expected output, we need to provide WRITE access for the trino user
+# to the Hive Warehouse directory.
+#
+# This is the error that we get without providing the access. Trino tries to create the schema directory and fails.
+# Query 20240701_134717_00010_39diz failed: Got exception: org.apache.hadoop.security.AccessControlException Permission denied: user=trino, access=WRITE, inode="/opt/hive/data":hadoop:supergroup:drwxr-xr-x
+#
+# To avoid getting the error, there are 3 workarounds.
+#
+# We can update Hive Warehouse directory to provide WRITE access for 'group'.
+#
+# changeHdfsDirPermissions "$HIVE_WAREHOUSE_PARENT_DIR" 775
+# changeHdfsDirPermissions "$HIVE_WAREHOUSE_DIR" 775
+#
+# or we can provide access through HDFS policies
+#
+# updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
+#
+# or we can create the directory that Trino needs in advance
+#
+# createHdfsDir "$HIVE_WAREHOUSE_DIR/gross_test.db"
 
 # Even if the directory exists, there won't be any errors. The command uses the '-p' option.
 createHdfsDir "$HIVE_WAREHOUSE_DIR/gross_test.db"
-
-# This is the error that we get without updating the Hive warehouse ACLs and creating the 'gross_test.db' directory.
-# Query 20240701_134717_00010_39diz failed: Got exception: org.apache.hadoop.security.AccessControlException Permission denied: user=trino, access=WRITE, inode="/opt/hive/data":hadoop:supergroup:drwxr-xr-x
 
 updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
 

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_8.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_8.sh
@@ -10,10 +10,6 @@ echo "## Test 8 ##"
 echo "Create a managed table"
 echo ""
 
-# BigData note: Create the tmp directory and provide world access to it so that Trino can use it.
-createHdfsDir "tmp"
-changeHdfsDirPermissions "tmp" 777
-
 # It's the same as in the previous test.
 updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
 

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_8.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_8.sh
@@ -10,7 +10,7 @@ echo "## Test 8 ##"
 echo "Create a managed table"
 echo ""
 
-# Create the tmp directory and provide world access to it so that Trino can use it.
+# BigData note: Create the tmp directory and provide world access to it so that Trino can use it.
 createHdfsDir "tmp"
 changeHdfsDirPermissions "tmp" 777
 

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_8.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_8.sh
@@ -10,15 +10,12 @@ echo "## Test 8 ##"
 echo "Create a managed table"
 echo ""
 
-# BigData note: "/*" isn't part of the BigData notes but it must have been added in a different policy.
-# If it's not there, then we get this error
-#
-# ==========================
-# Running trino command: 'insert into hive.gross_test.test values (1, 'Austin')'
-# --------------------------
-#
-# Query 20240704_105000_00008_b6t3t failed: Create temporary directory for hdfs://namenode/opt/hive/data/gross_test.db/test failed: Permission denied: user=trino, access=WRITE, inode="/":hadoop:supergroup:drwxr-xr-x
-updateHdfsPathPolicy "/*,/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
+# Create the tmp directory and provide world access to it so that Trino can use it.
+createHdfsDir "tmp"
+changeHdfsDirPermissions "tmp" 777
+
+# It's the same as in the previous test.
+updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
 
 # It's the same as in the previous test.
 updateHiveDbAllPolicy "gross_test" "alter,create,drop,index,lock,select,update:$TRINO_USER1"

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_9.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_9.sh
@@ -10,7 +10,7 @@ echo "## Test 9 ##"
 echo "Create a database in a location where the user is denied write access via a Ranger policy"
 echo ""
 
-# In the BigData notes, this test has no policy screenshots or any commands.
+# BigData note: In the notes, this test has no policy screenshots or any commands.
 # Just the title, an expected metadata SELECT error and a note 'Remove the Deny Condition and save your changes'.
 
 # The schema already exists. If we remove the SELECT access and run 'create schema',

--- a/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_9.sh
+++ b/trino-hms-hdfs-ranger/big-data-c3-tests/trino-spark-tests/trino/test_9.sh
@@ -25,7 +25,7 @@ echo ""
 #   - create the schema again.
 
 # It's the same as in the previous test.
-updateHdfsPathPolicy "/*,/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
+updateHdfsPathPolicy "/data/projects/gross_test,/$HIVE_WAREHOUSE_DIR/gross_test.db" "read,write,execute:$TRINO_USER1"
 
 # Remove select access.
 updateHiveDbAllPolicy "gross_test" "alter,create,drop,index,lock,update:$TRINO_USER1"

--- a/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/test_create_db_with_and_without_hive_url_policies.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/test_create_db_with_and_without_hive_url_policies.sh
@@ -80,7 +80,7 @@ if [ "$without_url" == 0 ]; then
   echo "When Hive URL policies are disabled and the coarse check is also disabled,"
   echo "then the hive plugin is recursively checking permissions for all sub-dirs under the provided path."
   echo "On the first permission check failure, the recursion stops."
-  echo "We are providing ACL access to the parent dir and all sub directories except the last."
+  echo "We are providing POSIX permission access to the parent dir and all sub directories except the last."
   echo "The operation should fail."
   echo ""
 
@@ -95,7 +95,7 @@ if [ "$with_url" == 0 ]; then
   setup "true"
 
   echo ""
-  echo "User [spark] has metadata access, Hive URL access and no HDFS policies access, but has Hadoop ACL access to the parent dir."
+  echo "User [spark] has metadata access, Hive URL access and no HDFS policies access, but has Hadoop POSIX permission access to the parent dir."
   echo "Because Hive URL policies are enabled, no sub-dirs should be checked for access. Operation should succeed."
   echo ""
 


### PR DESCRIPTION
## Changes in this PR

* Replaced all references to the `ACL` term with `POSIX permissions`
* Prefixed all comments referring to the BigData notes with `BigData note:` so that they are easier to spot
* `test_8.sh` creates a `tmp` dir and provides world access to it so that we can remove `/*` from the HDFS policies in this test and all the next ones
* Tried to make tests more consistent with the BigData notes
  * `test_7.sh` changing permissions was redundant
  * `test_9.sh` was updated to get the select error that appears in the notes
  * `test_12.sh - insert into` no longer gets an error on the tmp, it actually gets the EXECUTE error but trino swallows it and throws a TrinoException
  * `test_12.sh - create table` changed policies to be the same as in the notes and changed the expected error
* Removed unecessary changes
* Improved some comments