### PR TITLE
Reuse-c3_lib.sh-methods-1: Replace existing policy methods

### DIFF
--- a/trino-hms-hdfs-ranger/setup/setup_for_testing_hms_policies.sh
+++ b/trino-hms-hdfs-ranger/setup/setup_for_testing_hms_policies.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -10,10 +11,10 @@ abs_path=$1
 # We don't need to repeat it here.
 ./setup/setup_for_trino_spark_testing.sh "$abs_path"
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:trino,spark"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 sleep 15
 
 echo ""

--- a/trino-hms-hdfs-ranger/setup/setup_for_testing_hms_policies.sh
+++ b/trino-hms-hdfs-ranger/setup/setup_for_testing_hms_policies.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/setup/setup_for_testing_hms_url_policies.sh
+++ b/trino-hms-hdfs-ranger/setup/setup_for_testing_hms_url_policies.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -24,9 +25,9 @@ echo "- INFO: Updating Ranger policies. User [spark] will have Write permission 
 ./setup/load_ranger_policies.sh "$abs_path" "$HIVE_BASE_POLICIES"
 waitForPoliciesUpdate
 
-updateHdfsPathPolicy "read,write,execute:hadoop" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:trino,spark"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 sleep 15
 

--- a/trino-hms-hdfs-ranger/setup/setup_for_testing_hms_url_policies.sh
+++ b/trino-hms-hdfs-ranger/setup/setup_for_testing_hms_url_policies.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/setup/setup_for_trino_spark_testing.sh
+++ b/trino-hms-hdfs-ranger/setup/setup_for_trino_spark_testing.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/setup/setup_for_trino_spark_testing.sh
+++ b/trino-hms-hdfs-ranger/setup/setup_for_trino_spark_testing.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/testlib.sh
+++ b/trino-hms-hdfs-ranger/testlib.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "./big-data-c3-tests/lib.sh"
+
 # Project names
 PROJECT_RANGER="ranger"
 PROJECT_HADOOP="hadoop"

--- a/trino-hms-hdfs-ranger/testlib.sh
+++ b/trino-hms-hdfs-ranger/testlib.sh
@@ -996,13 +996,6 @@ retryOperationIfNeeded() {
   done
 }
 
-waitForPoliciesUpdate() {
-  wait_time_sec=30
-  echo ""
-  echo "- INFO: Waiting $wait_time_sec sec to make sure enough time has passed for the policies to get updated."
-  sleep "$wait_time_sec"
-}
-
 cpSparkTest() {
   testFilePath=$1
 
@@ -1023,19 +1016,6 @@ runSparkTest() {
   fi
 }
 
-# This function is created to allow for substitutes or changes if base64 works differently on different systems.
-# We can achieve the correct variable substitution and space handling by encoding and decoding the string.
-base64encode() {
-  input=$1
-
-  # Because of OS differences, it is necessary to use -w 0 for Linux distros.
-  if [[ $(uname) != "Darwin"* ]]; then
-    echo -n "$input" | base64 -w 0
-  else
-    echo -n "$input" | base64
-  fi
-}
-
 setupHdfsPathsAndPermissions() {
   # The default permissions have been set to
   #   - 700 for dirs
@@ -1050,43 +1030,4 @@ setupHdfsPathsAndPermissions() {
   changeHdfsPathPermissions "$HIVE_WAREHOUSE_ROOT_DIR" 755
   changeHdfsPathPermissions "$HIVE_WAREHOUSE_PARENT_DIR" 755
   changeHdfsPathPermissions "$HIVE_WAREHOUSE_DIR" 755
-}
-
-updateHdfsPathPolicy() {
-  # access1,access2:user1/access2,access4:user2
-  permissions=$1
-  path_list=$2
-
-  ./ranger_api/create_update/create_update_hdfs_path_policy.sh "put" "$permissions" "$path_list"
-}
-
-updateHiveDbAllPolicy() {
-  # access1,access2:user1/access2,access4:user2
-  permissions=$1
-  db_list=$2
-
-  ./ranger_api/create_update/create_update_hive_all_db_policy.sh "put" "$permissions" "$db_list"
-}
-
-updateHiveDefaultDbPolicy() {
-  # access1,access2:user1/access2,access4:user2
-  permissions=$1
-
-  ./ranger_api/create_update/create_update_hive_defaultdb_policy.sh "put" "$permissions"
-}
-
-updateHiveUrlPolicy() {
-  # access1,access2:user1/access2,access4:user2
-  permissions=$1
-  url_list=$2
-
-  ./ranger_api/create_update/create_update_hive_url_policy.sh "put" "$permissions" "$url_list"
-}
-
-createHiveUrlPolicy() {
-  # access1,access2:user1/access2,access4:user2
-  permissions=$1
-  url_list=$2
-
-  ./ranger_api/create_update/create_update_hive_url_policy.sh "create" "$permissions" "$url_list"
 }

--- a/trino-hms-hdfs-ranger/tests/hive_url_policies_env_setup.sh
+++ b/trino-hms-hdfs-ranger/tests/hive_url_policies_env_setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -32,7 +33,7 @@ retryOperationIfNeeded "$abs_path" "createHdfsDir $HIVE_GROSS_DB_TEST_DIR" "$not
 echo ""
 echo "Updating HDFS policies."
 echo ""
-updateHdfsPathPolicy "read,write,execute:hadoop,spark,trino" "/*"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark,trino"
 
 echo ""
 echo "---------------------------------------------------"
@@ -40,7 +41,7 @@ echo "---------------------------------------------------"
 echo ""
 echo "Updating Hive all db, cols, tables."
 echo ""
-updateHiveDbAllPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
+updateHiveDbAllPolicy "*" "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 
 echo ""
 echo "---------------------------------------------------"

--- a/trino-hms-hdfs-ranger/tests/hive_url_policies_env_setup.sh
+++ b/trino-hms-hdfs-ranger/tests/hive_url_policies_env_setup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/1_test_spark_no_hdfs_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/1_test_spark_no_hdfs_perms.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
 abs_path=$1
 
-updateHdfsPathPolicy "read,write,execute:hadoop" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,read:spark"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/1_test_spark_no_hdfs_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/1_test_spark_no_hdfs_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/2_test_spark_hdfs_perms_no_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/2_test_spark_hdfs_perms_no_hive_perms.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -10,10 +11,10 @@ echo ""
 echo "- INFO: Updating Ranger policies. User [spark] now will have [ALL] privileges on all HDFS paths."
 echo "- INFO: No user will have permissions on Hive metastore operations on the default db."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read:spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read:spark,trino"
 updateHiveDefaultDbPolicy "select,read:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/2_test_spark_hdfs_perms_no_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/2_test_spark_hdfs_perms_no_hive_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/3_test_spark_hdfs_hive_all.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/3_test_spark_hdfs_hive_all.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -9,10 +10,10 @@ abs_path=$1
 echo ""
 echo "- INFO: Updating Ranger policies. User [spark] will now have all access to Hive default DB."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/3_test_spark_hdfs_hive_all.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/3_test_spark_hdfs_hive_all.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/4_test_spark_only_select_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/4_test_spark_only_select_perm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -9,10 +10,10 @@ abs_path=$1
 echo ""
 echo "- INFO: Updating Ranger policies. User [spark] will now have only [select] access to Hive default DB."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/4_test_spark_only_select_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/4_test_spark_only_select_perm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/5_test_spark_select_alter_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/5_test_spark_select_alter_perm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -9,10 +10,10 @@ abs_path=$1
 echo ""
 echo "- INFO: Updating Ranger policies. User [spark] will now have [select, alter] access to Hive default DB."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,alter:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/5_test_spark_select_alter_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/5_test_spark_select_alter_perm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/6_test_spark_no_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/6_test_spark_no_drop_table_perm.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
 abs_path=$1
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,alter:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/6_test_spark_no_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/6_test_spark_no_drop_table_perm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/7_test_spark_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/7_test_spark_drop_table_perm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -9,10 +10,10 @@ abs_path=$1
 echo ""
 echo "- INFO: Updating Ranger policies. User [spark] will now have [drop] access to Hive default DB."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,alter,drop:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/7_test_spark_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/7_test_spark_drop_table_perm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/8_test_spark_no_select_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/8_test_spark_no_select_perm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/8_test_spark_no_select_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/8_test_spark_no_select_perm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -9,10 +10,10 @@ abs_path=$1
 echo ""
 echo "- INFO: Updating Ranger policies. User [spark] won't have any Hive privileges."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy ""
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/1_create_database_no_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/1_create_database_no_perms.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -12,10 +13,10 @@ echo "- INFO: User [spark] doesn't have HDFS permissions. The user will have onl
 echo "- INFO: Create database."
 echo "- INFO: User [spark] shouldn't be able to create database."
 
-updateHdfsPathPolicy "read,write,execute:hadoop" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,read:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/1_create_database_no_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/1_create_database_no_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/2_create_database_hdfs_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/2_create_database_hdfs_perms.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -10,10 +11,10 @@ echo ""
 echo "- INFO: Updating Ranger policies. User [spark] now will have [ALL] privileges on all HDFS paths."
 echo "- INFO: The user will also have 'select','read','create' Hive permissions."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read,create:spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read,create:spark,trino"
 updateHiveDefaultDbPolicy "select,read:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/2_create_database_hdfs_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/2_create_database_hdfs_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/3_drop_database_no_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/3_drop_database_no_perms.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
 abs_path=$1
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read,create:spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read,create:spark,trino"
 updateHiveDefaultDbPolicy "select,read:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/3_drop_database_no_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/3_drop_database_no_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/4_create_table_no_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/4_create_table_no_hive_perms.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -11,10 +12,10 @@ echo "- INFO: User [spark] has only 'select' Hive perms. Creating a table under 
 echo "- INFO: Create table."
 echo "- INFO: User [spark] shouldn't be able to create table."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read:spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read:spark,trino"
 updateHiveDefaultDbPolicy "select,read:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/4_create_table_no_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/4_create_table_no_hive_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/5_create_table_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/5_create_table_hive_perms.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -9,10 +10,10 @@ abs_path=$1
 echo ""
 echo "- INFO: Updating Ranger policies. User [spark] will now have all access to Hive $EXTERNAL_DB DB."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
 updateHiveDefaultDbPolicy ""
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/5_create_table_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/5_create_table_hive_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/6_drop_database_no_cascade.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/6_drop_database_no_cascade.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
 abs_path=$1
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
 updateHiveDefaultDbPolicy ""
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/6_drop_database_no_cascade.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/6_drop_database_no_cascade.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/7_drop_database_cascade.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/7_drop_database_cascade.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
 abs_path=$1
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
 updateHiveDefaultDbPolicy ""
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/database/7_drop_database_cascade.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/database/7_drop_database_cascade.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/1_test_create_database.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/1_test_create_database.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -21,10 +22,10 @@ retryOperationIfNeeded "$abs_path" "runSparkTest $SPARK_TEST_FOR_EXCEPTION_FILEN
 echo ""
 echo "Updating Hive URL policies."
 echo ""
-updateHdfsPathPolicy "read,write,execute:hadoop,spark,trino" "/*"
-updateHiveDbAllPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark,trino"
+updateHiveDbAllPolicy "*" "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveDefaultDbPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
-updateHiveUrlPolicy "read,write:spark"
+updateHiveUrlPolicy "*" "read,write:spark"
 
 echo ""
 echo "---------------------------------------------------"

--- a/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/1_test_create_database.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/1_test_create_database.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/2_test_select_drop_with_a_second_user.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/2_test_select_drop_with_a_second_user.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/2_test_select_drop_with_a_second_user.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/2_test_select_drop_with_a_second_user.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -10,10 +11,10 @@ echo ""
 echo "Test2-spark: ############### test select and drop with user 'games' ###############"
 echo ""
 
-updateHdfsPathPolicy "read,write,execute:hadoop,spark,trino" "/*"
-updateHiveDbAllPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark,trino"
+updateHiveDbAllPolicy "*" "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveDefaultDbPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
-updateHiveUrlPolicy "read,write:spark"
+updateHiveUrlPolicy "*" "read,write:spark"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/3_test_create_table_managed_and_not_managed.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/3_test_create_table_managed_and_not_managed.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -13,8 +14,8 @@ echo ""
 echo ""
 echo "Removing all Hive URL policies."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,spark,trino" "/*"
-updateHiveDbAllPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark,trino"
+updateHiveDbAllPolicy "*" "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveDefaultDbPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveUrlPolicy ""
 
@@ -66,10 +67,10 @@ retryOperationIfNeeded "$abs_path" "runSparkTest $SPARK_TEST_FOR_EXCEPTION_FILEN
 echo ""
 echo "Creating Hive URL policies again."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,spark,trino" "/*"
-updateHiveDbAllPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark,trino"
+updateHiveDbAllPolicy "*" "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveDefaultDbPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
-updateHiveUrlPolicy "read,write:spark"
+updateHiveUrlPolicy "*" "read,write:spark"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/3_test_create_table_managed_and_not_managed.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/3_test_create_table_managed_and_not_managed.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/4_test_alter_table_uri.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/4_test_alter_table_uri.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -20,8 +21,8 @@ retryOperationIfNeeded "$abs_path" "createHdfsDir $HIVE_GROSS_DB_TEST_DIR_SEC" "
 echo ""
 echo "Removing all Hive URL policies."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,spark,trino" "/*"
-updateHiveDbAllPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark,trino"
+updateHiveDbAllPolicy "*" "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveDefaultDbPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveUrlPolicy ""
 
@@ -44,10 +45,10 @@ retryOperationIfNeeded "$abs_path" "runSparkTest $SPARK_TEST_FOR_EXCEPTION_FILEN
 echo ""
 echo "Creating Hive URL policies again."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,spark,trino" "/*"
-updateHiveDbAllPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark,trino"
+updateHiveDbAllPolicy "*" "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveDefaultDbPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
-updateHiveUrlPolicy "read,write:spark"
+updateHiveUrlPolicy "*" "read,write:spark"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/4_test_alter_table_uri.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/4_test_alter_table_uri.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/test_create_db_with_and_without_hive_url_policies.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/test_create_db_with_and_without_hive_url_policies.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -52,20 +53,20 @@ setup() {
     echo ""
     echo "- INFO: Updating Ranger policies. User [spark] will have Write permission for Hive URL policy but no HDFS access."
 
-    updateHdfsPathPolicy "read,write,execute:hadoop" "/*"
-    updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark"
+    updateHdfsPathPolicy "/*" "read,write,execute:hadoop"
+    updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark"
     updateHiveDefaultDbPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:trino/select:spark"
-    updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,trino,spark"
+    updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,trino,spark"
 
     waitForPoliciesUpdate
   else
     echo ""
     echo "- INFO: Updating Ranger policies. User [spark] now will have all Hive access to default DB but no HDFS."
 
-    updateHdfsPathPolicy "read,write,execute:hadoop" "/*"
-    updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+    updateHdfsPathPolicy "/*" "read,write,execute:hadoop"
+    updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
     updateHiveDefaultDbPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:trino,spark"
-    updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+    updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
     waitForPoliciesUpdate
   fi

--- a/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/test_create_db_with_and_without_hive_url_policies.sh
+++ b/trino-hms-hdfs-ranger/tests/spark/hive_url_policies/test_create_db_with_and_without_hive_url_policies.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/test_all.sh
+++ b/trino-hms-hdfs-ranger/tests/test_all.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/test_all.sh
+++ b/trino-hms-hdfs-ranger/tests/test_all.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/test_hdfs_data_creation.sh
+++ b/trino-hms-hdfs-ranger/tests/test_hdfs_data_creation.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
-abs_path=$1
-
 # Load the default Ranger policies.
-updateHdfsPathPolicy "read,write,execute:hadoop" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,read:spark"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/test_hdfs_data_creation.sh
+++ b/trino-hms-hdfs-ranger/tests/test_hdfs_data_creation.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/1_test_trino_no_hdfs_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/1_test_trino_no_hdfs_perms.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
 abs_path=$1
 
-updateHdfsPathPolicy "read,write,execute:hadoop" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,read:spark"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/1_test_trino_no_hdfs_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/1_test_trino_no_hdfs_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/2_test_trino_hdfs_perms_no_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/2_test_trino_hdfs_perms_no_hive_perms.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -10,10 +11,10 @@ echo ""
 echo "- INFO: Updating Ranger policies. User [trino] now will have [ALL] privileges on all HDFS paths."
 echo "- INFO: No user will have permissions on Hive metastore operations on the default db."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy ""
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 echo ""
 echo "- INFO: This test is run after the schema tests." 

--- a/trino-hms-hdfs-ranger/tests/trino/2_test_trino_hdfs_perms_no_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/2_test_trino_hdfs_perms_no_hive_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/3_test_trino_hdfs_hive_all.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/3_test_trino_hdfs_hive_all.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -9,10 +10,10 @@ abs_path=$1
 echo ""
 echo "- INFO: Updating Ranger policies. User [trino] will now have all access to HDFS."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/3_test_trino_hdfs_hive_all.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/3_test_trino_hdfs_hive_all.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/4_test_trino_only_select_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/4_test_trino_only_select_perm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -10,10 +11,10 @@ echo ""
 echo "- INFO: Updating Ranger policies. User [trino] will now have only [select] access to Hive default DB."
 echo "- INFO: HDFS access for user [trino] has been removed."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/4_test_trino_only_select_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/4_test_trino_only_select_perm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/5_test_trino_select_alter_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/5_test_trino_select_alter_perm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -11,10 +12,10 @@ echo "- INFO: Updating Ranger policies."
 echo "- INFO: Users [trino] will now have [select, alter] access to Hive default DB."
 echo "- INFO: User [trino] will now have [Write] permission for HDFS policy."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,Alter:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/5_test_trino_select_alter_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/5_test_trino_select_alter_perm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/6_test_trino_no_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/6_test_trino_no_drop_table_perm.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
 abs_path=$1
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,Alter:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/6_test_trino_no_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/6_test_trino_no_drop_table_perm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/7_test_trino_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/7_test_trino_drop_table_perm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -9,10 +10,10 @@ abs_path=$1
 echo ""
 echo "- INFO: Updating Ranger policies. User [trino] will now have [drop] access to Hive default DB."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,Alter,drop:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/7_test_trino_drop_table_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/7_test_trino_drop_table_perm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/8_test_trino_no_select_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/8_test_trino_no_select_perm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -9,10 +10,10 @@ abs_path=$1
 echo ""
 echo "- INFO: Updating Ranger policies. User [trino] won't have any Hive privileges."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy ""
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/8_test_trino_no_select_perm.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/8_test_trino_no_select_perm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/1_test_create_schema.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/1_test_create_schema.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -19,10 +20,10 @@ retryOperationIfNeeded "$abs_path" "createSchemaWithTrino $GROSS_DB_NAME $HIVE_G
 echo ""
 echo "Updating Hive URL policies."
 echo ""
-updateHdfsPathPolicy "read,write,execute:hadoop,spark,trino" "/*"
-updateHiveDbAllPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark,trino"
+updateHiveDbAllPolicy "*" "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveDefaultDbPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
-updateHiveUrlPolicy "read,write:trino"
+updateHiveUrlPolicy "*" "read,write:trino"
 
 echo ""
 echo "---------------------------------------------------"

--- a/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/1_test_create_schema.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/1_test_create_schema.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/2_test_select_drop_with_a_second_user.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/2_test_select_drop_with_a_second_user.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -10,10 +11,10 @@ echo ""
 echo "Test2-trino: ############### test select and drop with user 'games' ###############"
 echo ""
 
-updateHdfsPathPolicy "read,write,execute:hadoop,spark,trino" "/*"
-updateHiveDbAllPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark,trino"
+updateHiveDbAllPolicy "*" "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveDefaultDbPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
-updateHiveUrlPolicy "read,write:trino"
+updateHiveUrlPolicy "*" "read,write:trino"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/2_test_select_drop_with_a_second_user.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/2_test_select_drop_with_a_second_user.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/3_test_create_table_managed_and_not_managed.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/3_test_create_table_managed_and_not_managed.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -13,8 +14,8 @@ echo ""
 echo ""
 echo "Removing all Hive URL policies."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,spark,trino" "/*"
-updateHiveDbAllPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark,trino"
+updateHiveDbAllPolicy "*" "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveDefaultDbPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveUrlPolicy ""
 
@@ -61,10 +62,10 @@ retryOperationIfNeeded "$abs_path" "performTrinoCmd trino $cmd" "$failMsg" "true
 echo ""
 echo "Creating Hive URL policies again."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,spark,trino" "/*"
-updateHiveDbAllPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,spark,trino"
+updateHiveDbAllPolicy "*" "select,update,create,drop,alter,index,lock:spark,trino/select:games"
 updateHiveDefaultDbPolicy "select,update,create,drop,alter,index,lock:spark,trino/select:games"
-updateHiveUrlPolicy "read,write:trino"
+updateHiveUrlPolicy "*" "read,write:trino"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/3_test_create_table_managed_and_not_managed.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/3_test_create_table_managed_and_not_managed.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/4_test_alter_table_uri.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/hive_url_policies/4_test_alter_table_uri.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-source "./testlib.sh"
-
 set -e
-
-abs_path=$1
 
 echo ""
 echo "Test4-trino: ############### rename table location without and with Hive URL policies ###############"

--- a/trino-hms-hdfs-ranger/tests/trino/schema/1_create_schema_no_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/1_create_schema_no_perms.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -13,10 +14,10 @@ echo "- INFO: User [trino] doesn't have HDFS or Hive permissions. The user will 
 echo "- INFO: Operation should fail."
 echo ""
 
-updateHdfsPathPolicy "read,write,execute:hadoop" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 updateHiveDefaultDbPolicy "select,read:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/1_create_schema_no_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/1_create_schema_no_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/2_create_schema_hdfs_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/2_create_schema_hdfs_perms.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -10,10 +11,10 @@ echo ""
 echo "- INFO: Updating Ranger policies. User [trino] now will have [ALL] privileges on all HDFS paths."
 echo "- INFO: The user will also have 'select','read','create' Hive permissions."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read,create:spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read,create:spark,trino"
 updateHiveDefaultDbPolicy "select,read:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/2_create_schema_hdfs_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/2_create_schema_hdfs_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/3_drop_schema_no_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/3_drop_schema_no_perms.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
 abs_path=$1
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read,create:spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read,create:spark,trino"
 updateHiveDefaultDbPolicy "select,read:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/3_drop_schema_no_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/3_drop_schema_no_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/4_create_table_no_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/4_create_table_no_hive_perms.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -11,10 +12,10 @@ echo "- INFO: User [trino] has only 'select' Hive perms. Creating a table under 
 echo ""
 
 # Failure due to lack of Hive metastore permissions.
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read:spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive/select,read:spark,trino"
 updateHiveDefaultDbPolicy "select,read:spark,trino"
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/4_create_table_no_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/4_create_table_no_hive_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/5_create_table_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/5_create_table_hive_perms.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
@@ -9,10 +10,10 @@ abs_path=$1
 echo ""
 echo "- INFO: Updating Ranger policies. User [trino] will now have all access to Hive $EXTERNAL_DB DB."
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
 updateHiveDefaultDbPolicy ""
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/5_create_table_hive_perms.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/5_create_table_hive_perms.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/6_drop_schema_no_cascade.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/6_drop_schema_no_cascade.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
 abs_path=$1
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
 updateHiveDefaultDbPolicy ""
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/6_drop_schema_no_cascade.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/6_drop_schema_no_cascade.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/7_drop_schema_cascade.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/7_drop_schema_cascade.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 source "./testlib.sh"
+source "./big-data-c3-tests/lib.sh"
 
 set -e
 
 abs_path=$1
 
-updateHdfsPathPolicy "read,write,execute:hadoop,trino,spark" "/*"
-updateHiveDbAllPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
+updateHdfsPathPolicy "/*" "read,write,execute:hadoop,trino,spark"
+updateHiveDbAllPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive,spark,trino"
 updateHiveDefaultDbPolicy ""
-updateHiveUrlPolicy "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
+updateHiveUrlPolicy "*" "select,update,Create,Drop,Alter,Index,Lock,All,Read,Write,ReplAdmin,Refresh:hive"
 
 waitForPoliciesUpdate
 

--- a/trino-hms-hdfs-ranger/tests/trino/schema/7_drop_schema_cascade.sh
+++ b/trino-hms-hdfs-ranger/tests/trino/schema/7_drop_schema_cascade.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source "./testlib.sh"
-source "./big-data-c3-tests/lib.sh"
 
 set -e
 


### PR DESCRIPTION
This is the 1st sub-PR from

https://github.com/xBis7/docker-setup-helper-scripts/pull/59

It's replacing all methods for setting Ranger policies. The main change is the order of the method parameters. The resources come first.

I've also removed the `base64encode` to avoid a conflict. It has the same method body, there are no further changes needed.